### PR TITLE
issue #5. Changed metadata descriptions for boundary kernels from WRI…

### DIFF
--- a/ocean/nemo/nemolite2d_psykal/boundary_conditions_mod.f90
+++ b/ocean/nemo/nemolite2d_psykal/boundary_conditions_mod.f90
@@ -47,7 +47,7 @@ module boundary_conditions_mod
 
   type, extends(kernel_type) :: bc_solid_u
      type(arg), dimension(2) :: meta_args =  &
-          (/ arg(WRITE, CU, POINTWISE),      &
+          (/ arg(READWRITE, CU, POINTWISE),  &
              arg(READ,      GRID_MASK_T)     &
            /)
 
@@ -73,7 +73,7 @@ module boundary_conditions_mod
 
   type, extends(kernel_type) :: bc_solid_v
      type(arg), dimension(2) :: meta_args =  &
-          (/ arg(WRITE, CV, POINTWISE),      &
+          (/ arg(READWRITE, CV, POINTWISE),  &
              arg(READ,      GRID_MASK_T)     &
            /)
 

--- a/ocean/nemo/nemolite2d_psykal_ocl/kernels/boundary_conditions_kern.c
+++ b/ocean/nemo/nemolite2d_psykal_ocl/kernels/boundary_conditions_kern.c
@@ -35,7 +35,7 @@
 
   type, extends(kernel_type) :: bc_solid_u
      type(arg), dimension(2) :: meta_args =  &
-          (/ arg(WRITE, CU, POINTWISE),      &
+          (/ arg(READWRITE, CU, POINTWISE),  &
              arg(READ,      GRID_MASK_T)     &
            /)
 
@@ -61,7 +61,7 @@
 /*
   type, extends(kernel_type) :: bc_solid_v
      type(arg), dimension(2) :: meta_args =  &
-          (/ arg(WRITE, CV, POINTWISE),      &
+          (/ arg(READWRITE, CV, POINTWISE),  &
              arg(READ,      GRID_MASK_T)     &
            /)
 

--- a/ocean/nemo/nemolite2d_psykal_omp/boundary_conditions_mod.f90
+++ b/ocean/nemo/nemolite2d_psykal_omp/boundary_conditions_mod.f90
@@ -45,7 +45,7 @@ module boundary_conditions_mod
 
   type, extends(kernel_type) :: bc_solid_u
      type(arg), dimension(2) :: meta_args =  &
-          (/ arg(WRITE, CU, POINTWISE),      &
+          (/ arg(READWRITE, CU, POINTWISE),  &
              arg(READ,      GRID_MASK_T)     &
            /)
 
@@ -70,7 +70,7 @@ module boundary_conditions_mod
 
   type, extends(kernel_type) :: bc_solid_v
      type(arg), dimension(2) :: meta_args =  &
-          (/ arg(WRITE, CV, POINTWISE),      &
+          (/ arg(READWRITE, CV, POINTWISE),  &
              arg(READ,      GRID_MASK_T)     &
            /)
 


### PR DESCRIPTION
Changed metadata for fields in two boundary kernels from WRITE to READWRITE. PSyclone generated nemo/psykal code is identical in both cases.