### PR TITLE
Fix missing CC export from gnu.sh compiler setup script.

### DIFF
--- a/compiler_setup/gnu.sh
+++ b/compiler_setup/gnu.sh
@@ -26,3 +26,4 @@ export F90FLAGS
 export OMPFLAGS
 export LDFLAGS
 export AR
+export CC


### PR DESCRIPTION
The CC environment variable wasn't being exporting from the compiler setup script for gnu compiler toolchain, so if you're on a system where default CC != gcc (i.e. macOS where cc == clang) then the compilation will fail, complaining about OpenMP flags.