### PR TITLE
Add more initialization options for the namelist jphgr_msh parameter and fix C++OpenMP flather_v loop

### DIFF
--- a/benchmarks/nemo/nemolite2d/common/model_mod.f90
+++ b/benchmarks/nemo/nemolite2d/common/model_mod.f90
@@ -167,30 +167,6 @@ CONTAINS
           end if
        end if
 
-       ! Eastern boundary
-       if(subdomain%global%xstop == jpi)then
-          ! Eastern global boundary may be open (tidally forced)
-          ! Make the open boundary outside the computational domain
-          ! (i.e. ystart - 1)
-          if (jphgr_msh .eq. 2 .or. jphgr_msh .eq. 3) then
-            tmask(subdomain%internal%xstop+1:, :) = -1
-          else
-            tmask(subdomain%internal%xstop+1:, :) = 0
-          endif
-       else
-          ! Subdomain is not at the easternmost extent of the global
-          ! domain so boundary is wet.
-          do jj = subdomain%internal%ystart, subdomain%internal%ystop
-             tmask(subdomain%internal%xstop+1:, jj) = 1
-          end do
-
-          if(subdomain%global%ystop /= jpj)then
-             ! NE corner of this sub-domain is internal so corner halo
-             ! points are all wet
-             tmask(subdomain%internal%xstop+1:,subdomain%internal%ystop+1:) = 1
-          end if
-       end if
-
        ! Northern boundary
        if(subdomain%global%ystop == jpj)then
           ! North solid boundary
@@ -208,6 +184,30 @@ CONTAINS
           end if
           if(subdomain%global%xstop /= jpi)then
              ! NE corner is internal and thus halo pts are wet
+             tmask(subdomain%internal%xstop+1:,subdomain%internal%ystop+1:) = 1
+          end if
+       end if
+
+       ! Eastern boundary
+       if(subdomain%global%xstop == jpi)then
+          ! Eastern global boundary may be open (tidally forced)
+          ! Make the open boundary outside the computational domain
+          ! (i.e. xstart + 1)
+          if (jphgr_msh .eq. 2 .or. jphgr_msh .eq. 3) then
+            tmask(subdomain%internal%xstop+1:, :) = -1
+          else
+            tmask(subdomain%internal%xstop+1:, :) = 0
+          endif
+       else
+          ! Subdomain is not at the easternmost extent of the global
+          ! domain so boundary is wet.
+          do jj = subdomain%internal%ystart, subdomain%internal%ystop
+             tmask(subdomain%internal%xstop+1:, jj) = 1
+          end do
+
+          if(subdomain%global%ystop /= jpj)then
+             ! NE corner of this sub-domain is internal so corner halo
+             ! points are all wet
              tmask(subdomain%internal%xstop+1:,subdomain%internal%ystop+1:) = 1
           end if
        end if

--- a/benchmarks/nemo/nemolite2d/common/model_mod.f90
+++ b/benchmarks/nemo/nemolite2d/common/model_mod.f90
@@ -192,7 +192,7 @@ CONTAINS
        if(subdomain%global%xstop == jpi)then
           ! Eastern global boundary may be open (tidally forced)
           ! Make the open boundary outside the computational domain
-          ! (i.e. xstart + 1)
+          ! (i.e. xstop + 1)
           if (jphgr_msh .eq. 2 .or. jphgr_msh .eq. 3) then
             tmask(subdomain%internal%xstop+1:, :) = -1
           else

--- a/benchmarks/nemo/nemolite2d/common/model_mod.f90
+++ b/benchmarks/nemo/nemolite2d/common/model_mod.f90
@@ -133,10 +133,13 @@ CONTAINS
        ! xt(jpi,jpj), yt(jpi,jpj)
        ! ht(jpi,jpj), hu(jpi,jpj), hv(jpi,jpj)
 
-    case(1)
+    case(1:3)
 
        ! A manually defined T mask
        ! Define Model solid/open Boundaries via the properties of t-cells
+       ! If jphgr_msh is 1, the southern boundary is open
+       ! If jphgr_msh is 2, the eastern boundary is open
+       ! If jphgr_msh is 3, the southern and eastern boundaries are open
 
        tmask(:,:) = 0 ! Default all cells to being dry/outside the domain
 
@@ -166,8 +169,14 @@ CONTAINS
 
        ! Eastern boundary
        if(subdomain%global%xstop == jpi)then
-          ! Eastern boundary of global domain is solid
-          tmask(subdomain%internal%xstop+1:, :) = 0
+          ! Eastern global boundary may be open (tidally forced)
+          ! Make the open boundary outside the computational domain
+          ! (i.e. ystart - 1)
+          if (jphgr_msh .eq. 2 .or. jphgr_msh .eq. 3) then
+            tmask(subdomain%internal%xstop+1:, :) = -1
+          else
+            tmask(subdomain%internal%xstop+1:, :) = 0
+          endif
        else
           ! Subdomain is not at the easternmost extent of the global
           ! domain so boundary is wet.
@@ -205,10 +214,14 @@ CONTAINS
 
        ! Southern boundary
        if(subdomain%global%ystart == 1)then
-          ! Southern global boundary is open (tidally forced)
+          ! Southern global boundary may be open (tidally forced)
           ! Make the open boundary outside the computational domain
           ! (i.e. ystart - 1)
-          tmask(:, :subdomain%internal%ystart-1) = -1
+          if (jphgr_msh .eq. 1 .or. jphgr_msh .eq. 3) then
+            tmask(:, :subdomain%internal%ystart-1) = -1
+          else
+            tmask(:, :subdomain%internal%ystart-1) = 0
+          endif
        else
           ! Subdomain is not at the southernmost extent of the domain so
           ! does not have an open boundary
@@ -229,8 +242,8 @@ CONTAINS
     case DEFAULT
        ! undefined jphgr_msh value
        ! add interrupt here
-       call gocean_stop("Wrong grid definition type (jphgr_msh must be 0 "// &
-                        "or 1), check your namelist file.")
+       call gocean_stop("Wrong grid definition type (jphgr_msh must be 0"// &
+                        ", 1, 2 or 3), check your namelist file.")
     end select
 
   end subroutine setup_tpoints_mask

--- a/benchmarks/nemo/nemolite2d/manual_versions/namelist
+++ b/benchmarks/nemo/nemolite2d/manual_versions/namelist
@@ -3,7 +3,7 @@
 !-----------------------------------------------------------------------
    jpiglo      =    1024               !  number of columns of model grid
    jpjglo      =    1024               !  number of rows of model grid
-   jphgr_msh   =       1               !  type of grid (0: read in a data file; 1: setup with following parameters)
+   jphgr_msh   =       3               !  type of grid (0: read in a data file; 1: southern boundary open; 2: eastern boundary open; 3: southern and eastern boundaries open)
    dx          =    1000.0             !  grid size in x direction (m)
    dy          =    1000.0             !  grid size in y direction (m)
    dep_const   =     100.0             !  constant depth (m)

--- a/benchmarks/nemo/nemolite2d/manual_versions/namelist
+++ b/benchmarks/nemo/nemolite2d/manual_versions/namelist
@@ -3,7 +3,7 @@
 !-----------------------------------------------------------------------
    jpiglo      =    1024               !  number of columns of model grid
    jpjglo      =    1024               !  number of rows of model grid
-   jphgr_msh   =       3               !  type of grid (0: read in a data file; 1: southern boundary open; 2: eastern boundary open; 3: southern and eastern boundaries open)
+   jphgr_msh   =       1               !  type of grid (0: read in a data file; 1: southern boundary open; 2: eastern boundary open; 3: southern and eastern boundaries open)
    dx          =    1000.0             !  grid size in x direction (m)
    dy          =    1000.0             !  grid size in y direction (m)
    dep_const   =     100.0             !  constant depth (m)

--- a/benchmarks/nemo/nemolite2d/manual_versions/psykal_cpp/time_step_omp.cpp
+++ b/benchmarks/nemo/nemolite2d/manual_versions/psykal_cpp/time_step_omp.cpp
@@ -115,7 +115,8 @@ extern "C" void c_invoke_time_step(
     }
 
     // Boundary conditions bc_flather_v kernel (whole domain but top y boundary)
-    #pragma omp parallel for
+    // We cannot execute this loop in (OpenMP) parallel because of the
+    // loop-carried dependency in j.
     for(int jj = internal_ystart - 1; jj <= internal_ystop; jj++){
         for(int ji = internal_xstart - 1; ji <= internal_xstop + 1; ji++){
             bc_flather_v_code(ji, jj, width, va, hv, sshn_v, tmask, g);

--- a/benchmarks/nemo/nemolite2d/manual_versions/psykal_cpp/time_step_ompopt.cpp
+++ b/benchmarks/nemo/nemolite2d/manual_versions/psykal_cpp/time_step_ompopt.cpp
@@ -102,7 +102,8 @@ extern "C" void c_invoke_time_step(
     }
 
     // Boundary conditions bc_flather_v kernel (whole domain but top y boundary)
-    #pragma omp parallel for
+    // We cannot execute this loop in (OpenMP) parallel because of the
+    // loop-carried dependency in j.
     for(int jj = internal_ystart - 1; jj <= internal_ystop; jj++){
         for(int ji = internal_xstart - 1; ji <= internal_xstop + 1; ji++){
             bc_flather_v_code(ji, jj, width, va, hv, sshn_v, tmask, g);


### PR DESCRIPTION
Issue #48 

This PR adds the possibility to initialize grids with different open boundaries and fixes the discrepancy between OpenMP Fortran and C++ noted by @AidanChalk .
