### PR TITLE
Optimise OpenCL implementations for Xilinx FPGA

### DIFF
--- a/benchmarks/nemo/nemolite2d/manual_versions/psykal_opencl/Makefile
+++ b/benchmarks/nemo/nemolite2d/manual_versions/psykal_opencl/Makefile
@@ -27,15 +27,19 @@ nemolite2d.exe: ${COMMON_LIB} inf_lib timer_lib fcl_lib ${COMMON_MODULES}
 # The generated device file can be used with:
 # > FORTCL_KERNELS_FILE=device_binary ./nemolite2d.exe
 device_binary: allkernels.cl
-	${OCL_COMPILER} $< -o $<.xo
-	${OCL_LINKER} $<.xo -o $@.xclbin
+	${OCL_COMPILER} ${OCL_DEVICE_FLAGS} --platform ${FPGA_PLATFORM} \
+		--target ${FPGA_EXECUTION_TARGET} $< -o $<.xo
+	${OCL_LINKER} ${OCL_DEVICE_FLAGS} --platform ${FPGA_PLATFORM} \
+		--target ${FPGA_EXECUTION_TARGET} $<.xo -o $@.xclbin
 
 device_binary_nohup:
 	nohup make device_binary > nohup.out &
 
 device_binary_tasks: allkernels_tasks.cl
-	${OCL_COMPILER} $< -o $<.xo
-	${OCL_LINKER} $<.xo -o $@.xclbin
+	${OCL_COMPILER} ${OCL_DEVICE_FLAGS} --platform ${FPGA_PLATFORM} \
+		--target ${FPGA_EXECUTION_TARGET} $< -o $<.xo
+	${OCL_LINKER} ${OCL_DEVICE_FLAGS} --platform ${FPGA_PLATFORM} \
+		--target ${FPGA_EXECUTION_TARGET} $<.xo -o $@.xclbin
 
 device_binary_tasks_nohup:
 	nohup make device_binary_tasks > nohup.out &
@@ -46,6 +50,7 @@ run_jit:
 clean:
 	rm -f *.o *.mod *~ gnu_opt_report.txt *.optrpt *.dat *.log
 	rm -rf _x device_binary.* allkernels.cl.* nohup.out .ipcache
+	rm -rf device_binary_tasks.* allkernels_tasks.cl.*
 
 allclean: clean
 	rm -f *.exe

--- a/benchmarks/nemo/nemolite2d/manual_versions/psykal_opencl/allkernels_tasks.cl
+++ b/benchmarks/nemo/nemolite2d/manual_versions/psykal_opencl/allkernels_tasks.cl
@@ -38,6 +38,8 @@ __kernel void bc_flather_u_code(
   for (int jj = ystart; jj <= ystop; jj++){
 
       // Burst data reads
+      // This must be independent loops otherwise the Xilinx compiler
+      // produces significantly slower memory read operations.
       for (int ji = xstart; ji <= xstop; ji++){
         ua_buffer[ji] = ua[jj * LEN + ji];
       }
@@ -54,7 +56,7 @@ __kernel void bc_flather_u_code(
       // Computation loop
       for (int ji = xstart; ji <= xstop; ji++){
           if (!((tmask_buffer[ji] + tmask_buffer[ji + 1]) <= (-1))) {
-              if ((tmask[jj * LEN + ji] < 0)) {
+              if ((tmask_buffer[jj * LEN + ji] < 0)) {
                 ua_buffer[ji] = (ua_buffer[ji + 1] + (sqrt((g / hu_buffer[ji])) * (sshn_u_buffer[ji] - sshn_u_buffer[ji + 1])));
               } else {
                 if ((tmask_buffer[ji + 1] < 0)) {
@@ -101,6 +103,8 @@ __kernel void bc_flather_v_code(
   for (int jj = ystart; jj <= ystop; jj++){
 
       // Burst data reads
+      // This must be independent loops otherwise the Xilinx compiler
+      // produces significantly slower memory read operations.
       for (int ji = xstart; ji <= xstop; ji++){
         va_buffer[ji] = va[jj * LEN + ji];
       }
@@ -113,7 +117,6 @@ __kernel void bc_flather_v_code(
       for (int ji = xstart; ji <= xstop; ji++){
         tmask_buffer[ji] = tmask[jj * LEN + ji];
       }
-
       for (int ji = xstart; ji <= xstop; ji++){
         tmask_nextrow[ji] = tmask[(jj+1) * LEN + ji];
       }
@@ -163,8 +166,8 @@ __kernel void bc_solid_u_code(
   const __global int * restrict tmask
   ){
   for (int jj = ystart; jj <= ystop; jj++){
-      double this_tmask;
-      double next_tmask = tmask[jj * LEN + xstart];
+      int this_tmask;
+      int next_tmask = tmask[jj * LEN + xstart];
       for (int ji = xstart; ji <= xstop; ji++){
           this_tmask = next_tmask;
           next_tmask = tmask[jj * LEN + (ji + 1)];
@@ -186,8 +189,8 @@ __kernel void bc_solid_v_code(
   __global double * restrict va,
   const __global int * restrict tmask
   ){
-  double this_row[LEN];
-  double next_row[LEN];
+  int this_row[LEN];
+  int next_row[LEN];
   for (int ji = xstart; ji <= xstop; ji++){
       next_row[ji] = tmask[ystart * LEN + ji];
   }
@@ -225,12 +228,14 @@ __kernel void bc_ssh_code(
   double rtime = ((double)istep * rdt);
   double value = (amp_tide * sin((omega_tide * rtime)));
 
-  // Temporal buffers
+  // Temporary buffers
   int tmask_p1[LEN];
   int tmask_this[LEN];
   int tmask_m1[LEN];
   
-  // Next: can also buffer ssha
+  // Burst data reads
+  // This must be independent loops otherwise the Xilinx compiler
+  // produces significantly slower memory read operations.
   for (int ji = xstart; ji <= xstop; ji++){
     tmask_m1[ji] = tmask[(ystart - 1) * LEN + ji];
   }
@@ -313,6 +318,8 @@ __kernel void continuity_code(
   double vn_previousrow[LEN];
 
   // Burst load previous rows
+  // This must be independent loops otherwise the Xilinx compiler
+  // produces significantly slower memory read operations.
   for (int ji = xstart; ji <= xstop; ji++){
     ssh_v_previousrow[ji] = sshn_v[(ystart - 1) * LEN + ji];
   }
@@ -463,7 +470,6 @@ __kernel void momentum_u_code(
   // Create buffers for burst copies
   double ua_buffer[LEN];
   double un_buffer[LEN];
-  //#pragma HLS array_partition variable=un_buffer cyclic factor=3
   double vn_buffer[LEN];
   double hu_buffer[LEN];
   double hv_buffer[LEN];
@@ -497,6 +503,8 @@ __kernel void momentum_u_code(
   int e2u_nextrow[LEN];
 
   // Load initial data for nextrow that are needed to populate buffers
+  // This must be independent loops otherwise the Xilinx compiler
+  // produces significantly slower memory read operations.
   for (int ji = xstart; ji <= xstop; ji++){
     un_nextrow[ji] = un[ystart * LEN + ji];
   }
@@ -786,6 +794,8 @@ __kernel void momentum_v_code(
   double e2t_nextrow[LEN];
 
   // Load initial data for nextrow that are needed to populate buffers
+  // This must be independent loops otherwise the Xilinx compiler
+  // produces significantly slower memory read operations.
   for (int ji = xstart; ji <= xstop; ji++){
     un_nextrow[ji] = un[ystart * LEN + ji];
   }
@@ -997,6 +1007,8 @@ __kernel void next_sshu_code(
   for (int jj = ystart; jj <= ystop; jj++){
 
       // Burst data reads
+      // This must be independent loops otherwise the Xilinx compiler
+      // produces significantly slower memory read operations.
       for (int ji = xstart; ji <= xstop; ji++){
         sshn_buffer[ji] = sshn[jj * LEN + ji];
       }
@@ -1063,6 +1075,8 @@ __kernel void next_sshv_code(
   for (int jj = ystart; jj <= ystop; jj++){
 
       // Burst data reads
+      // This must be independent loops otherwise the Xilinx compiler
+      // produces significantly slower memory read operations.
       for (int ji = xstart; ji <= xstop; ji++){
         sshn_buffer[ji] = sshn[jj * LEN + ji];
       }

--- a/benchmarks/nemo/nemolite2d/manual_versions/psykal_opencl/allkernels_tasks.cl
+++ b/benchmarks/nemo/nemolite2d/manual_versions/psykal_opencl/allkernels_tasks.cl
@@ -5,6 +5,10 @@
 // - Added vec_type_hint(double) and xcl_zero_global_work_offset kernels hints.
 // - Added const attributes.
 // - Removed duplicated LEN expressions.
+// - Add buffers in each kernel to burst read and write from memory blocks of LEN
+// size. Then the body of the kernel access this data from the buffer (which is a
+// register instead of memory) which significantly improve performance on the Xilinx
+// platform.
 
 
 // LEN value predefined for a problem size of 250x250
@@ -81,6 +85,7 @@ __kernel void bc_flather_v_code(
   const __global int * restrict tmask,
   double g
   ){
+
   // Create buffers for burst copies
   double va_buffer[LEN];
   double hv_buffer[LEN];
@@ -109,7 +114,6 @@ __kernel void bc_flather_v_code(
         tmask_buffer[ji] = tmask[jj * LEN + ji];
       }
 
-      // Others
       for (int ji = xstart; ji <= xstop; ji++){
         tmask_nextrow[ji] = tmask[(jj+1) * LEN + ji];
       }
@@ -241,6 +245,7 @@ __kernel void bc_ssh_code(
         tmask_p1[ji] = tmask[(jj+1) * LEN + ji];
       }
 
+      // Computation loop
       for (int ji = xstart; ji <= xstop; ji++){
           if (!(tmask[jj * LEN + ji] <= 0)) {
               if ((tmask_m1[ji] < 0)) {
@@ -349,6 +354,7 @@ __kernel void continuity_code(
         vn_buffer[ji] = vn[jj * LEN + ji];
       }
 
+      // Computation loop
       for (int ji = xstart; ji <= xstop; ji++){
           double this_sshn_u = sshn_u_buffer[ji];
           double this_hu = hu_buffer[ji];
@@ -636,6 +642,7 @@ __kernel void momentum_u_code(
         e2u_nextrow[ji] = e2u[(jj+1) * LEN + ji];
       }
 
+      // Computation loop
       for (int ji = xstart; ji <= xstop; ji++){
           if (((tmask_buffer[ji] + tmask_buffer[(ji + 1)]) <= 0)) {
             continue;
@@ -909,6 +916,7 @@ __kernel void momentum_v_code(
         e2t_nextrow[ji] = e2t[(jj+1) * LEN + ji];
       }
 
+      // Computation loop
       for (int ji = xstart; ji <= xstop; ji++){
           if (((tmask_buffer[ji] + tmask_buffer[(ji + 1)]) <= 0)) {
             continue;
@@ -1002,6 +1010,7 @@ __kernel void next_sshu_code(
         e12u_buffer[ji] = e12u[jj * LEN + ji];
       }
 
+      // Computation loop
       for (int ji = xstart; ji <= xstop; ji++){
           if (((tmask_buffer[ji] + tmask_buffer[(ji + 1)]) <= 0)) {
             continue;
@@ -1077,7 +1086,7 @@ __kernel void next_sshv_code(
         e12t_nextrow[ji] = e12t[(jj+1) * LEN + ji];
       }
         
-
+      // Computation loop
       for (int ji = xstart; ji <= xstop; ji++){
           if (((tmask_buffer[ji] + tmask_nextrow[ji]) <= 0)) {
             continue;

--- a/benchmarks/nemo/nemolite2d/manual_versions/psykal_opencl/allkernels_tasks.cl
+++ b/benchmarks/nemo/nemolite2d/manual_versions/psykal_opencl/allkernels_tasks.cl
@@ -24,20 +24,46 @@ __kernel void bc_flather_u_code(
   const __global int * restrict tmask,
   double g
   ){
+
+  // Create buffers for burst copies
+  double ua_buffer[LEN];
+  double hu_buffer[LEN];
+  double sshn_u_buffer[LEN];
+  int tmask_buffer[LEN];
+
   for (int jj = ystart; jj <= ystop; jj++){
+
+      // Burst data reads
       for (int ji = xstart; ji <= xstop; ji++){
-          int jiu;
-          if (!((tmask[jj * LEN + ji] + tmask[jj * LEN + (ji + 1)]) <= (-1))) {
+        ua_buffer[ji] = ua[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        hu_buffer[ji] = hu[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        sshn_u_buffer[ji] = sshn_u[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        tmask_buffer[ji] = tmask[jj * LEN + ji];
+      }
+
+
+      // Next optimisation: Put ji-/+1 in separate registers
+      for (int ji = xstart; ji <= xstop; ji++){
+          if (!((tmask_buffer[ji] + tmask_buffer[ji + 1]) <= (-1))) {
               if ((tmask[jj * LEN + ji] < 0)) {
-                jiu = (ji + 1);
-                ua[jj * LEN + ji] = (ua[jj * LEN + jiu] + (sqrt((g / hu[jj * LEN + ji])) * (sshn_u[jj * LEN + ji] - sshn_u[jj * LEN + jiu])));
+                ua_buffer[ji] = (ua_buffer[ji + 1] + (sqrt((g / hu_buffer[ji])) * (sshn_u_buffer[ji] - sshn_u_buffer[ji + 1])));
               } else {
-                if ((tmask[jj * LEN + (ji + 1)] < 0)) {
-                  jiu = (ji - 1);
-                  ua[jj * LEN + ji] = (ua[jj * LEN + jiu] + (sqrt((g / hu[jj * LEN + ji])) * (sshn_u[jj * LEN + ji] - sshn_u[jj * LEN + jiu])));
+                if ((tmask_buffer[ji + 1] < 0)) {
+                  ua_buffer[ji] = (ua_buffer[ji - 1] + (sqrt((g / hu_buffer[ji])) * (sshn_u_buffer[ji] - sshn_u_buffer[ji - 1])));
                 }
               }
           }
+      }
+
+      // Burst data write
+      for (int ji = xstart; ji <= xstop; ji++){
+        ua[jj * LEN + ji] = ua_buffer[ji];
       }
   }
 }
@@ -56,27 +82,71 @@ __kernel void bc_flather_v_code(
   const __global int * restrict tmask,
   double g
   ){
+  // Create buffers for burst copies
+  double va_buffer[LEN];
+  double hv_buffer[LEN];
+  double sshn_v_buffer[LEN];
+  int tmask_buffer[LEN];
+
+  int tmask_nextrow[LEN];
+  double va_previousrow[LEN];
+  double va_nextrow[LEN];
+  double sshn_v_previousrow[LEN];
+  double sshn_v_nextrow[LEN];
+
   for (int jj = ystart; jj <= ystop; jj++){
+
+      // Burst data reads
       for (int ji = xstart; ji <= xstop; ji++){
-          if (((tmask[jj * LEN + ji] + tmask[(jj + 1) * LEN + ji]) <= (-1))) {
+        va_buffer[ji] = va[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        hv_buffer[ji] = hv[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        sshn_v_buffer[ji] = sshn_v[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        tmask_buffer[ji] = tmask[jj * LEN + ji];
+      }
+
+      // Others
+      for (int ji = xstart; ji <= xstop; ji++){
+        tmask_nextrow[ji] = tmask[(jj+1) * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        va_previousrow[ji] = va[(jj-1) * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        va_nextrow[ji] = va[(jj+1) * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        sshn_v_previousrow[ji] = sshn_v[(jj-1) * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        sshn_v_nextrow[ji] = sshn_v[(jj+1) * LEN + ji];
+      }
+
+      for (int ji = xstart; ji <= xstop; ji++){
+          if (((tmask_buffer[ji] + tmask_nextrow[ji]) <= (-1))) {
             continue;
           }
-          int jiv;
-          if ((tmask[jj * LEN + ji] < 0)) {
-            jiv = (jj + 1);
-            va[jj * LEN + ji] = (va[jiv * LEN + ji] + (sqrt((g / hv[jj * LEN + ji])) * (sshn_v[jj * LEN + ji] - sshn_v[jiv * LEN + ji])));
+          if ((tmask_buffer[ji] < 0)) {
+            va_buffer[ji] = (va_nextrow[ji] + (sqrt((g / hv_buffer[ji])) * (sshn_v_buffer[ji] - sshn_v_nextrow[ji])));
           } else {
-            if ((tmask[(jj + 1) * LEN + ji] < 0)) {
-              jiv = (jj - 1);
-              va[jj * LEN + ji] = (va[jiv * LEN + ji] + (sqrt((g / hv[jj * LEN + ji])) * (sshn_v[jj * LEN + ji] - sshn_v[jiv * LEN + ji])));
+            if ((tmask_nextrow[ji] < 0)) {
+              va_buffer[ji] = (va_previousrow[ji] + (sqrt((g / hv_buffer[ji])) * (sshn_v_buffer[ji] - sshn_v_previousrow[ji])));
             }
           }
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        va[jj * LEN + ji] = va_buffer[ji];
       }
   }
 }
 
 __attribute__((vec_type_hint(double)))
-__attribute__ ((reqd_work_group_size(1, 1, 1)))
+__attribute__((reqd_work_group_size(1, 1, 1)))
 __attribute__((xcl_zero_global_work_offset))
 __kernel void bc_solid_u_code(
   int xstart,
@@ -87,8 +157,12 @@ __kernel void bc_solid_u_code(
   const __global int * restrict tmask
   ){
   for (int jj = ystart; jj <= ystop; jj++){
+      double this_tmask;
+      double next_tmask = tmask[jj * LEN + xstart];
       for (int ji = xstart; ji <= xstop; ji++){
-          if (((tmask[jj * LEN + ji] * tmask[jj * LEN + (ji + 1)]) == 0)) {
+          this_tmask = next_tmask;
+          next_tmask = tmask[jj * LEN + (ji + 1)];
+          if (((this_tmask * next_tmask) == 0)) {
             ua[jj * LEN + ji] = 0.;
           }
       }
@@ -106,9 +180,20 @@ __kernel void bc_solid_v_code(
   __global double * restrict va,
   const __global int * restrict tmask
   ){
+  double this_row[LEN];
+  double next_row[LEN];
+  for (int ji = xstart; ji <= xstop; ji++){
+      next_row[ji] = tmask[ystart * LEN + ji];
+  }
+
   for (int jj = ystart; jj <= ystop; jj++){
       for (int ji = xstart; ji <= xstop; ji++){
-          if (((tmask[jj * LEN + ji] * tmask[(jj + 1) * LEN + ji]) == 0)) {
+          this_row[ji] = next_row[ji];
+          next_row[ji] = tmask[(jj + 1) * LEN + ji];
+      }
+
+      for (int ji = xstart; ji <= xstop; ji++){
+          if ((this_row[ji] * next_row[jj]) == 0) {
             va[jj * LEN + ji] = 0.;
           }
       }
@@ -128,29 +213,59 @@ __kernel void bc_ssh_code(
   const __global int * restrict tmask,
   double rdt
   ){
+
+  double amp_tide = 0.2;
+  double omega_tide = ((2.0 * 3.14159) / (12.42 * 3600.));
+  double rtime = ((double)istep * rdt);
+  double value = (amp_tide * sin((omega_tide * rtime)));
+
+  // Temporal buffers
+  int tmask_p1[LEN];
+  int tmask_this[LEN];
+  int tmask_m1[LEN];
+  
+  // Next: can also buffer ssha
+  for (int ji = xstart; ji <= xstop; ji++){
+    tmask_m1[ji] = tmask[(ystart - 1) * LEN + ji];
+  }
+  for (int ji = xstart; ji <= xstop; ji++){
+    tmask_this[ji] = tmask[ystart * LEN + ji];
+  }
+
+
   for (int jj = ystart; jj <= ystop; jj++){
+
       for (int ji = xstart; ji <= xstop; ji++){
-          double amp_tide = 0.2;
-          double omega_tide = ((2.0 * 3.14159) / (12.42 * 3600.));
-          double rtime = ((double)istep * rdt);
+        tmask_p1[ji] = tmask[(jj+1) * LEN + ji];
+      }
+
+      for (int ji = xstart; ji <= xstop; ji++){
           if (!(tmask[jj * LEN + ji] <= 0)) {
-              if ((tmask[(jj - 1) * LEN + ji] < 0)) {
-                ssha[jj * LEN + ji] = (amp_tide * sin((omega_tide * rtime)));
+              if ((tmask_m1[ji] < 0)) {
+                ssha[jj * LEN + ji] = value;
               } else {
-                if ((tmask[(jj + 1) * LEN + ji] < 0)) {
-                  ssha[jj * LEN + ji] = (amp_tide * sin((omega_tide * rtime)));
+                if ((tmask_p1[ji] < 0)) {
+                  ssha[jj * LEN + ji] = value;
                 } else {
-                  if ((tmask[jj * LEN + (ji + 1)] < 0)) {
-                    ssha[jj * LEN + ji] = (amp_tide * sin((omega_tide * rtime)));
+                  if ((tmask_this[ji+1] < 0)) {
+                    ssha[jj * LEN + ji] = value;
                   } else {
-                    if ((tmask[jj * LEN + (ji - 1)] < 0)) {
-                      ssha[jj * LEN + ji] = (amp_tide * sin((omega_tide * rtime)));
+                    if ((tmask_this[ji-1] < 0)) {
+                      ssha[jj * LEN + ji] = value;
                     }
                   }
                 }
               }
           }
       }
+
+      for (int ji = xstart; ji <= xstop; ji++){
+        tmask_m1[ji] = tmask_this[ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        tmask_this[ji] = tmask_p1[ji];
+      }
+
   }
 }
 
@@ -173,13 +288,92 @@ __kernel void continuity_code(
   const __global double * restrict e12t,
   double rdt
   ){
+  // Create buffers for burst copies
+  double ssha_buffer[LEN];
+  double sshn_buffer[LEN];
+  double e12t_buffer[LEN];
+
+  double sshn_u_buffer[LEN];
+  double hu_buffer[LEN];
+  double un_buffer[LEN];
+  double sshn_v_buffer[LEN];
+  double hv_buffer[LEN];
+  double vn_buffer[LEN];
+
+  // Create row cache to to save a row for the next jj iteration
+  double ssh_v_previousrow[LEN];
+  double hv_previousrow[LEN];
+  double vn_previousrow[LEN];
+
+  // Burst load previous rows
+  for (int ji = xstart; ji <= xstop; ji++){
+    ssh_v_previousrow[ji] = sshn_v[(ystart - 1) * LEN + ji];
+  }
+  for (int ji = xstart; ji <= xstop; ji++){
+    hv_previousrow[ji] = hv[(ystart - 1) * LEN + ji];
+  }
+  for (int ji = xstart; ji <= xstop; ji++){
+    vn_previousrow[ji] = vn[(ystart - 1) * LEN + ji];
+  }
+
   for (int jj = ystart; jj <= ystop; jj++){
+      // Keep a copy of this 3 values for the next ji iteration
+      double sshn_u_jim1 = sshn_u[jj * LEN + (xstart - 1)];
+      double hu_jim1 = hu[jj * LEN + (xstart - 1)];
+      double un_jim1 = un[jj * LEN + (xstart - 1)];
+
       for (int ji = xstart; ji <= xstop; ji++){
-          double rtmp1 = ((sshn_u[jj * LEN + ji] + hu[jj * LEN + ji]) * un[jj * LEN + ji]);
-          double rtmp2 = ((sshn_u[jj * LEN + (ji - 1)] + hu[jj * LEN + (ji - 1)]) * un[jj * LEN + (ji - 1)]);
-          double rtmp3 = ((sshn_v[jj * LEN + ji] + hv[jj * LEN + ji]) * vn[jj * LEN + ji]);
-          double rtmp4 = ((sshn_v[(jj - 1) * LEN + ji] + hv[(jj - 1) * LEN + ji]) * vn[(jj - 1) * LEN + ji]);
-          ssha[jj * LEN + ji] = (sshn[jj * LEN + ji] + (((((rtmp2 - rtmp1) + rtmp4) - rtmp3) * rdt) / e12t[jj * LEN + ji]));
+        sshn_buffer[ji] = sshn[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        e12t_buffer[ji] = e12t[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        sshn_u_buffer[ji] = sshn_u[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        hu_buffer[ji] = hu[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        un_buffer[ji] = un[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        sshn_v_buffer[ji] = sshn_v[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        hv_buffer[ji] = hv[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        vn_buffer[ji] = vn[jj * LEN + ji];
+      }
+
+      for (int ji = xstart; ji <= xstop; ji++){
+          double this_sshn_u = sshn_u_buffer[ji];
+          double this_hu = hu_buffer[ji];
+          double this_un = un_buffer[ji];
+
+          double this_sshn_v = sshn_v_buffer[ji];
+          double this_hv = hv_buffer[ji];
+          double this_vn = vn_buffer[ji];
+
+          // Kernel computation
+          double rtmp1 = ((this_sshn_u + this_hu) * this_un);
+          double rtmp2 = ((sshn_u_jim1 + hu_jim1) * un_jim1);
+          double rtmp3 = ((this_sshn_v + this_hv) * this_vn);
+          double rtmp4 = ((ssh_v_previousrow[ji] + hv_previousrow[ji]) * vn_previousrow[ji]);
+          ssha_buffer[ji] = (sshn_buffer[ji] + (((((rtmp2 - rtmp1) + rtmp4) - rtmp3) * rdt) / e12t_buffer[ji]));
+
+          // Save the current values in registers for next iteration
+          sshn_u_jim1 = this_sshn_u;
+          hu_jim1 = this_hu;
+          un_jim1 = this_un;
+          ssh_v_previousrow[ji] = this_sshn_v; 
+          hv_previousrow[ji] = this_hv;
+          vn_previousrow[ji] = this_vn;
+      }
+
+      for (int ji = xstart; ji <= xstop; ji++){
+        ssha[jj * LEN + ji] = ssha_buffer[ji];
       }
   }
 }
@@ -257,54 +451,193 @@ __kernel void momentum_u_code(
   double uu_n;
   double uu_s;
   double uu_w;
+
+  // Create buffers for burst copies
+  double ua_buffer[LEN];
+  double un_buffer[LEN];
+  double vn_buffer[LEN];
+  double hu_buffer[LEN];
+  double hv_buffer[LEN];
+  double ht_buffer[LEN];
+  double ssha_u_buffer[LEN];
+  double sshn_buffer[LEN];
+  double sshn_u_buffer[LEN];
+  double sshn_v_buffer[LEN];
+  int tmask_buffer[LEN];
+  double e1u_buffer[LEN];
+  double e1v_buffer[LEN];
+  double e1t_buffer[LEN];
+  double e2u_buffer[LEN];
+  double e2t_buffer[LEN];
+  double e12u_buffer[LEN];
+  double gphiu_buffer[LEN];
+
+  double un_previousrow[LEN];
+  double un_nextrow[LEN];
+  double vn_previousrow[LEN];
+  double hu_previousrow[LEN];
+  double hu_nextrow[LEN];
+  double hv_previousrow[LEN];
+  double sshn_u_previousrow[LEN];
+  double sshn_u_nextrow[LEN];
+  double sshn_v_previousrow[LEN];
+  int tmask_previousrow[LEN];
+  int tmask_nextrow[LEN];
+  int e1v_previousrow[LEN];
+  int e2u_previousrow[LEN];
+  int e2u_nextrow[LEN];
+
   for (int jj = ystart; jj <= ystop; jj++){
+
+      // Burst data reads
       for (int ji = xstart; ji <= xstop; ji++){
-          if (((tmask[jj * LEN + ji] + tmask[jj * LEN + (ji + 1)]) <= 0)) {
+        ua_buffer[ji] = ua[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        un_buffer[ji] = un[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        vn_buffer[ji] = vn[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        hu_buffer[ji] = hu[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        hv_buffer[ji] = hv[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        ht_buffer[ji] = ht[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        ssha_u_buffer[ji] = ssha_u[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        sshn_buffer[ji] = sshn[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        sshn_u_buffer[ji] = sshn_u[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        sshn_v_buffer[ji] = sshn_v[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        tmask_buffer[ji] = tmask[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        e1u_buffer[ji] = e1u[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        e1v_buffer[ji] = e1v[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        e1t_buffer[ji] = e1t[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        e2u_buffer[ji] = e2u[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        e2t_buffer[ji] = e2t[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        e12u_buffer[ji] = e12u[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        gphiu_buffer[ji] = gphiu[jj * LEN + ji];
+      }
+      // Other rows copies
+      for (int ji = xstart; ji <= xstop; ji++){
+        un_previousrow[ji] = un[(jj-1) * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        un_nextrow[ji] = un[(jj+1) * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        vn_previousrow[ji] = vn[(jj-1) * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        hu_previousrow[ji] = hu[(jj-1) * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        hu_nextrow[ji] = hu[(jj+1) * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        hv_previousrow[ji] = hv[(jj-1) * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        sshn_u_previousrow[ji] = sshn_u[(jj-1) * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        sshn_u_nextrow[ji] = sshn_u[(jj+1) * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        sshn_v_previousrow[ji] = sshn_v[(jj-1) * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        tmask_previousrow[ji] = tmask[(jj-1) * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        tmask_nextrow[ji] = tmask[(jj+1) * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        e1v_previousrow[ji] = e1v[(jj-1) * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        e2u_previousrow[ji] = e2u[(jj-1) * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        e2u_nextrow[ji] = e2u[(jj+1) * LEN + ji];
+      }
+
+      for (int ji = xstart; ji <= xstop; ji++){
+          if (((tmask_buffer[ji] + tmask_buffer[(ji + 1)]) <= 0)) {
             continue;
           }
-          if (((tmask[jj * LEN + ji] <= 0) || (tmask[jj * LEN + (ji + 1)] <= 0))) {
+          if (((tmask_buffer[ji] <= 0) || (tmask_buffer[(ji + 1)] <= 0))) {
             continue;
           }
-          u_e = ((0.5 * (un[jj * LEN + ji] + un[jj * LEN + (ji + 1)])) * e2t[jj * LEN + (ji + 1)]);
-          depe = (ht[jj * LEN + (ji + 1)] + sshn[jj * LEN + (ji + 1)]);
-          u_w = ((0.5 * (un[jj * LEN + ji] + un[jj * LEN + (ji - 1)])) * e2t[jj * LEN + ji]);
-          depw = (ht[jj * LEN + ji] + sshn[jj * LEN + ji]);
-          v_sc = (0.5 * (vn[(jj - 1) * LEN + ji] + vn[(jj - 1) * LEN + (ji + 1)]));
-          v_s = ((0.5 * v_sc) * (e1v[(jj - 1) * LEN + ji] + e1v[(jj - 1) * LEN + (ji + 1)]));
-          deps = (0.5 * (((hv[(jj - 1) * LEN + ji] + sshn_v[(jj - 1) * LEN + ji]) + hv[(jj - 1) * LEN + (ji + 1)]) + sshn_v[(jj - 1) * LEN + (ji + 1)]));
-          v_nc = (0.5 * (vn[jj * LEN + ji] + vn[jj * LEN + (ji + 1)]));
-          v_n = ((0.5 * v_nc) * (e1v[jj * LEN + ji] + e1v[jj * LEN + (ji + 1)]));
-          depn = (0.5 * (((hv[jj * LEN + ji] + sshn_v[jj * LEN + ji]) + hv[jj * LEN + (ji + 1)]) + sshn_v[jj * LEN + (ji + 1)]));
-          uu_w = (((0.5 - copysign(0.5, u_w)) * un[jj * LEN + ji]) + ((0.5 + copysign(0.5, u_w)) * un[jj * LEN + (ji - 1)]));
-          uu_e = (((0.5 + copysign(0.5, u_e)) * un[jj * LEN + ji]) + ((0.5 - copysign(0.5, u_e)) * un[jj * LEN + (ji + 1)]));
-          if (((tmask[(jj - 1) * LEN + ji] <= 0) || (tmask[(jj - 1) * LEN + (ji + 1)] <= 0))) {
-            uu_s = ((0.5 - copysign(0.5, v_s)) * un[jj * LEN + ji]);
+          u_e = ((0.5 * (un_buffer[ji] + un_buffer[(ji + 1)])) * e2t_buffer[(ji + 1)]);
+          depe = (ht_buffer[(ji + 1)] + sshn_buffer[(ji + 1)]);
+          u_w = ((0.5 * (un_buffer[ji] + un_buffer[(ji - 1)])) * e2t_buffer[ji]);
+          depw = (ht_buffer[ji] + sshn_buffer[ji]);
+          v_sc = (0.5 * (vn_previousrow[ji] + vn_previousrow[(ji + 1)]));
+          v_s = ((0.5 * v_sc) * (e1v_previousrow[ji] + e1v_previousrow[(ji + 1)]));
+          deps = (0.5 * (((hv_previousrow[ji] + sshn_v_previousrow[ji]) + hv_previousrow[(ji + 1)]) + sshn_v_previousrow[(ji + 1)]));
+          v_nc = (0.5 * (vn_buffer[ji] + vn_buffer[(ji + 1)]));
+          v_n = ((0.5 * v_nc) * (e1v_buffer[ji] + e1v_buffer[(ji + 1)]));
+          depn = (0.5 * (((hv_buffer[ji] + sshn_v_buffer[ji]) + hv_buffer[(ji + 1)]) + sshn_v_buffer[(ji + 1)]));
+          uu_w = (((0.5 - copysign(0.5, u_w)) * un_buffer[ji]) + ((0.5 + copysign(0.5, u_w)) * un_buffer[(ji - 1)]));
+          uu_e = (((0.5 + copysign(0.5, u_e)) * un_buffer[ji]) + ((0.5 - copysign(0.5, u_e)) * un_buffer[(ji + 1)]));
+          if (((tmask_previousrow[ji] <= 0) || (tmask_previousrow[(ji + 1)] <= 0))) {
+            uu_s = ((0.5 - copysign(0.5, v_s)) * un_buffer[ji]);
           } else {
-            uu_s = (((0.5 - copysign(0.5, v_s)) * un[jj * LEN + ji]) + ((0.5 + copysign(0.5, v_s)) * un[(jj - 1) * LEN + ji]));
+            uu_s = (((0.5 - copysign(0.5, v_s)) * un_buffer[ji]) + ((0.5 + copysign(0.5, v_s)) * un_previousrow[ji]));
           }
-          if (((tmask[(jj + 1) * LEN + ji] <= 0) || (tmask[(jj + 1) * LEN + (ji + 1)] <= 0))) {
-            uu_n = ((0.5 + copysign(0.5, v_n)) * un[jj * LEN + ji]);
+          if (((tmask_nextrow[ji] <= 0) || (tmask_nextrow[(ji + 1)] <= 0))) {
+            uu_n = ((0.5 + copysign(0.5, v_n)) * un_buffer[ji]);
           } else {
-            uu_n = (((0.5 + copysign(0.5, v_n)) * un[jj * LEN + ji]) + ((0.5 - copysign(0.5, v_n)) * un[(jj + 1) * LEN + ji]));
+            uu_n = (((0.5 + copysign(0.5, v_n)) * un_buffer[ji]) + ((0.5 - copysign(0.5, v_n)) * un_nextrow[ji]));
           }
           adv = (((((uu_w * u_w) * depw) - ((uu_e * u_e) * depe)) + ((uu_s * v_s) * deps)) - ((uu_n * v_n) * depn));
-          dudx_e = (((un[jj * LEN + (ji + 1)] - un[jj * LEN + ji]) / e1t[jj * LEN + (ji + 1)]) * (ht[jj * LEN + (ji + 1)] + sshn[jj * LEN + (ji + 1)]));
-          dudx_w = (((un[jj * LEN + ji] - un[jj * LEN + (ji - 1)]) / e1t[jj * LEN + ji]) * (ht[jj * LEN + ji] + sshn[jj * LEN + ji]));
-          if (((tmask[(jj - 1) * LEN + ji] <= 0) || (tmask[(jj - 1) * LEN + (ji + 1)] <= 0))) {
+          dudx_e = (((un_buffer[(ji + 1)] - un_buffer[ji]) / e1t_buffer[(ji + 1)]) * (ht_buffer[(ji + 1)] + sshn_buffer[(ji + 1)]));
+          dudx_w = (((un_buffer[ji] - un_buffer[(ji - 1)]) / e1t_buffer[ji]) * (ht_buffer[ji] + sshn_buffer[ji]));
+          if (((tmask_previousrow[ji] <= 0) || (tmask_previousrow[(ji + 1)] <= 0))) {
             dudy_s = 0.0;
           } else {
-            dudy_s = (((un[jj * LEN + ji] - un[(jj - 1) * LEN + ji]) / (e2u[jj * LEN + ji] + e2u[(jj - 1) * LEN + ji])) * (((hu[jj * LEN + ji] + sshn_u[jj * LEN + ji]) + hu[(jj - 1) * LEN + ji]) + sshn_u[(jj - 1) * LEN + ji]));
+            dudy_s = (((un_buffer[ji] - un_previousrow[ji]) / (e2u_buffer[ji] + e2u_previousrow[ji])) * (((hu_buffer[ji] + sshn_u_buffer[ji]) + hu_previousrow[ji]) + sshn_u_previousrow[ji]));
           }
-          if (((tmask[(jj + 1) * LEN + ji] <= 0) || (tmask[(jj + 1) * LEN + (ji + 1)] <= 0))) {
+          if (((tmask_nextrow[ji] <= 0) || (tmask_nextrow[(ji + 1)] <= 0))) {
             dudy_n = 0.0;
           } else {
-            dudy_n = (((un[(jj + 1) * LEN + ji] - un[jj * LEN + ji]) / (e2u[jj * LEN + ji] + e2u[(jj + 1) * LEN + ji])) * (((hu[jj * LEN + ji] + sshn_u[jj * LEN + ji]) + hu[(jj + 1) * LEN + ji]) + sshn_u[(jj + 1) * LEN + ji]));
+            dudy_n = (((un_nextrow[ji] - un_buffer[ji]) / (e2u_buffer[ji] + e2u_nextrow[ji])) * (((hu_buffer[ji] + sshn_u_buffer[ji]) + hu_nextrow[ji]) + sshn_u_nextrow[ji]));
           }
-          vis = (((dudx_e - dudx_w) * e2u[jj * LEN + ji]) + (((dudy_n - dudy_s) * e1u[jj * LEN + ji]) * 0.5));
+          vis = (((dudx_e - dudx_w) * e2u_buffer[ji]) + (((dudy_n - dudy_s) * e1u_buffer[ji]) * 0.5));
           vis = (visc * vis);
-          cor = (((0.5 * (((2. * omega) * sin((gphiu[jj * LEN + ji] * d2r))) * (v_sc + v_nc))) * e12u[jj * LEN + ji]) * (hu[jj * LEN + ji] + sshn_u[jj * LEN + ji]));
-          hpg = (-(((g * (hu[jj * LEN + ji] + sshn_u[jj * LEN + ji])) * e2u[jj * LEN + ji]) * (sshn[jj * LEN + (ji + 1)] - sshn[jj * LEN + ji])));
-          ua[jj * LEN + ji] = ((((un[jj * LEN + ji] * (hu[jj * LEN + ji] + sshn_u[jj * LEN + ji])) + ((rdt * (((adv + vis) + cor) + hpg)) / e12u[jj * LEN + ji])) / (hu[jj * LEN + ji] + ssha_u[jj * LEN + ji])) / (1.0 + (cbfr * rdt)));
+          cor = (((0.5 * (((2. * omega) * sin((gphiu_buffer[ji] * d2r))) * (v_sc + v_nc))) * e12u_buffer[ji]) * (hu_buffer[ji] + sshn_u_buffer[ji]));
+          hpg = (-(((g * (hu_buffer[ji] + sshn_u_buffer[ji])) * e2u_buffer[ji]) * (sshn_buffer[(ji + 1)] - sshn_buffer[ji])));
+          ua_buffer[ji] = ((((un_buffer[ji] * (hu_buffer[ji] + sshn_u_buffer[ji])) + ((rdt * (((adv + vis) + cor) + hpg)) / e12u_buffer[ji])) / (hu_buffer[ji] + ssha_u_buffer[ji])) / (1.0 + (cbfr * rdt)));
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        ua[jj * LEN + ji] = ua_buffer[ji];
       }
   }
 }
@@ -364,55 +697,185 @@ __kernel void momentum_v_code(
   double dvdx_w;
   double dvdy_n;
   double dvdy_s;
+
+  // Create buffers for burst copies
+  double va_buffer[LEN];
+  double un_buffer[LEN];
+  double vn_buffer[LEN];
+  double hu_buffer[LEN];
+  double hv_buffer[LEN];
+  double ht_buffer[LEN];
+  double ssha_v_buffer[LEN];
+  double sshn_buffer[LEN];
+  double sshn_u_buffer[LEN];
+  double sshn_v_buffer[LEN];
+  int tmask_buffer[LEN];
+  double e1v_buffer[LEN];
+  double e1t_buffer[LEN];
+  double e2u_buffer[LEN];
+  double e2v_buffer[LEN];
+  double e2t_buffer[LEN];
+  double e12v_buffer[LEN];
+  double gphiv_buffer[LEN];
+
+  double un_nextrow[LEN];
+  double vn_previousrow[LEN];
+  double vn_nextrow[LEN];
+  double hu_nextrow[LEN];
+  double ht_nextrow[LEN];
+  double sshn_nextrow[LEN];
+  double sshn_u_nextrow[LEN];
+  int tmask_nextrow[LEN];
+  double e1t_nextrow[LEN];
+  double e2u_nextrow[LEN];
+  double e2t_nextrow[LEN];
+
   for (int jj = ystart; jj <= ystop; jj++){
+
+      // Burst buffer reads
       for (int ji = xstart; ji <= xstop; ji++){
-          if (((tmask[jj * LEN + ji] + tmask[jj * LEN + (ji + 1)]) <= 0)) {
+        va_buffer[ji] = va[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        un_buffer[ji] = un[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        vn_buffer[ji] = vn[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        hu_buffer[ji] = hu[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        hv_buffer[ji] = hv[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        ht_buffer[ji] = ht[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        ssha_v_buffer[ji] = ssha_v[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        sshn_buffer[ji] = sshn[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        sshn_u_buffer[ji] = sshn_u[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        sshn_v_buffer[ji] = sshn_v[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        tmask_buffer[ji] = tmask[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        e1v_buffer[ji] = e1v[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        e1t_buffer[ji] = e1t[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        e2u_buffer[ji] = e2u[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        e2v_buffer[ji] = e2v[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        e2t_buffer[ji] = e2t[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        e12v_buffer[ji] = e12v[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        gphiv_buffer[ji] = gphiv[jj * LEN + ji];
+      }
+
+
+      for (int ji = xstart; ji <= xstop; ji++){
+        un_nextrow[ji] = un[(jj+1) * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        vn_previousrow[ji] = vn[(jj-1) * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        vn_nextrow[ji] = vn[(jj+1) * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        hu_nextrow[ji] = hu[(jj+1) * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        ht_nextrow[ji] = ht[(jj+1) * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        sshn_nextrow[ji] = sshn[(jj+1) * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        sshn_u_nextrow[ji] = sshn_u[(jj+1) * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        tmask_nextrow[ji] = tmask[(jj+1) * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        e1t_nextrow[ji] = e1t[(jj+1) * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        e2u_nextrow[ji] = e2u[(jj+1) * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        e2t_nextrow[ji] = e2t[(jj+1) * LEN + ji];
+      }
+
+      for (int ji = xstart; ji <= xstop; ji++){
+          if (((tmask_buffer[ji] + tmask_buffer[(ji + 1)]) <= 0)) {
             continue;
           }
-          if (((tmask[jj * LEN + ji] <= 0) || (tmask[(jj + 1) * LEN + ji] <= 0))) {
+          if (((tmask_buffer[ji] <= 0) || (tmask_nextrow[ji] <= 0))) {
             continue;
           }
-          v_n = ((0.5 * (vn[jj * LEN + ji] + vn[(jj + 1) * LEN + ji])) * e1t[(jj + 1) * LEN + ji]);
-          depn = (ht[(jj + 1) * LEN + ji] + sshn[(jj + 1) * LEN + ji]);
-          v_s = ((0.5 * (vn[jj * LEN + ji] + vn[(jj - 1) * LEN + ji])) * e1t[jj * LEN + ji]);
-          deps = (ht[jj * LEN + ji] + sshn[jj * LEN + ji]);
-          u_wc = (0.5 * (un[jj * LEN + (ji - 1)] + un[(jj + 1) * LEN + (ji - 1)]));
-          u_w = ((0.5 * u_wc) * (e2u[jj * LEN + (ji - 1)] + e2u[(jj + 1) * LEN + (ji - 1)]));
-          depw = (0.50 * (((hu[jj * LEN + (ji - 1)] + sshn_u[jj * LEN + (ji - 1)]) + hu[(jj + 1) * LEN + (ji - 1)]) + sshn_u[(jj + 1) * LEN + (ji - 1)]));
-          u_ec = (0.5 * (un[jj * LEN + ji] + un[(jj + 1) * LEN + ji]));
-          u_e = ((0.5 * u_ec) * (e2u[jj * LEN + ji] + e2u[(jj + 1) * LEN + ji]));
-          depe = (0.50 * (((hu[jj * LEN + ji] + sshn_u[jj * LEN + ji]) + hu[(jj + 1) * LEN + ji]) + sshn_u[(jj + 1) * LEN + ji]));
-          vv_s = (((0.5 - copysign(0.5, v_s)) * vn[jj * LEN + ji]) + ((0.5 + copysign(0.5, v_s)) * vn[(jj - 1) * LEN + ji]));
-          vv_n = (((0.5 + copysign(0.5, v_n)) * vn[jj * LEN + ji]) + ((0.5 - copysign(0.5, v_n)) * vn[(jj + 1) * LEN + ji]));
-          if (((tmask[jj * LEN + (ji - 1)] <= 0) || (tmask[(jj + 1) * LEN + (ji - 1)] <= 0))) {
-            vv_w = ((0.5 - copysign(0.5, u_w)) * vn[jj * LEN + ji]);
+          v_n = ((0.5 * (vn_buffer[ji] + vn_nextrow[ji])) * e1t_nextrow[ji]);
+          depn = (ht_nextrow[ji] + sshn_nextrow[ji]);
+          v_s = ((0.5 * (vn_buffer[ji] + vn_previousrow[ji])) * e1t_buffer[ji]);
+          deps = (ht_nextrow[ji] + sshn_buffer[ji]);
+          u_wc = (0.5 * (un_buffer[(ji - 1)] + un_nextrow[(ji - 1)]));
+          u_w = ((0.5 * u_wc) * (e2u_buffer[(ji - 1)] + e2u_nextrow[(ji - 1)]));
+          depw = (0.50 * (((hu_buffer[(ji - 1)] + sshn_u_buffer[(ji - 1)]) + hu_nextrow[(ji - 1)]) + sshn_u_nextrow[(ji - 1)]));
+          u_ec = (0.5 * (un_buffer[ji] + un_nextrow[ji]));
+          u_e = ((0.5 * u_ec) * (e2u_buffer[ji] + e2u_nextrow[ji]));
+          depe = (0.50 * (((hu_buffer[ji] + sshn_u_buffer[ji]) + hu_nextrow[ji]) + sshn_u_nextrow[ji]));
+          vv_s = (((0.5 - copysign(0.5, v_s)) * vn_buffer[ji]) + ((0.5 + copysign(0.5, v_s)) * vn_previousrow[ji]));
+          vv_n = (((0.5 + copysign(0.5, v_n)) * vn_buffer[ji]) + ((0.5 - copysign(0.5, v_n)) * vn_nextrow[ji]));
+          if (((tmask_buffer[(ji - 1)] <= 0) || (tmask_nextrow[(ji - 1)] <= 0))) {
+            vv_w = ((0.5 - copysign(0.5, u_w)) * vn_buffer[ji]);
           } else {
-            vv_w = (((0.5 - copysign(0.5, u_w)) * vn[jj * LEN + ji]) + ((0.5 + copysign(0.5, u_w)) * vn[jj * LEN + (ji - 1)]));
+            vv_w = (((0.5 - copysign(0.5, u_w)) * vn_buffer[ji]) + ((0.5 + copysign(0.5, u_w)) * vn_buffer[(ji - 1)]));
           }
-          if (((tmask[jj * LEN + (ji + 1)] <= 0) || (tmask[(jj + 1) * LEN + (ji + 1)] <= 0))) {
-            vv_e = ((0.5 + copysign(0.5, u_e)) * vn[jj * LEN + ji]);
+          if (((tmask_buffer[(ji + 1)] <= 0) || (tmask_nextrow[(ji + 1)] <= 0))) {
+            vv_e = ((0.5 + copysign(0.5, u_e)) * vn_buffer[ji]);
           } else {
-            vv_e = (((0.5 + copysign(0.5, u_e)) * vn[jj * LEN + ji]) + ((0.5 - copysign(0.5, u_e)) * vn[jj * LEN + (ji + 1)]));
+            vv_e = (((0.5 + copysign(0.5, u_e)) * vn_buffer[ji]) + ((0.5 - copysign(0.5, u_e)) * vn_buffer[(ji + 1)]));
           }
           adv = (((((vv_w * u_w) * depw) - ((vv_e * u_e) * depe)) + ((vv_s * v_s) * deps)) - ((vv_n * v_n) * depn));
-          dvdy_n = (((vn[(jj + 1) * LEN + ji] - vn[jj * LEN + ji]) / e2t[(jj + 1) * LEN + ji]) * (ht[(jj + 1) * LEN + ji] + sshn[(jj + 1) * LEN + ji]));
-          dvdy_s = (((vn[jj * LEN + ji] - vn[(jj - 1) * LEN + ji]) / e2t[jj * LEN + ji]) * (ht[jj * LEN + ji] + sshn[jj * LEN + ji]));
-          if (((tmask[jj * LEN + (ji - 1)] <= 0) || (tmask[(jj + 1) * LEN + (ji - 1)] <= 0))) {
+          dvdy_n = (((vn_nextrow[ji] - vn_buffer[ji]) / e2t_nextrow[ji]) * (ht_nextrow[ji] + sshn_nextrow[ji]));
+          dvdy_s = (((vn_buffer[ji] - vn_previousrow[ji]) / e2t_buffer[ji]) * (ht_buffer[ji] + sshn_buffer[ji]));
+          if (((tmask_buffer[(ji - 1)] <= 0) || (tmask_nextrow[(ji - 1)] <= 0))) {
             dvdx_w = 0.0;
           } else {
-            dvdx_w = (((vn[jj * LEN + ji] - vn[jj * LEN + (ji - 1)]) / (e1v[jj * LEN + ji] + e1v[jj * LEN + (ji - 1)])) * (((hv[jj * LEN + ji] + sshn_v[jj * LEN + ji]) + hv[jj * LEN + (ji - 1)]) + sshn_v[jj * LEN + (ji - 1)]));
+            dvdx_w = (((vn_buffer[ji] - vn_buffer[(ji - 1)]) / (e1v_buffer[ji] + e1v_buffer[(ji - 1)])) * (((hv_buffer[ji] + sshn_v_buffer[ji]) + hv_buffer[(ji - 1)]) + sshn_v_buffer[(ji - 1)]));
           }
-          if (((tmask[jj * LEN + (ji + 1)] <= 0) || (tmask[(jj + 1) * LEN + (ji + 1)] <= 0))) {
+          if (((tmask_buffer[(ji + 1)] <= 0) || (tmask_nextrow[(ji + 1)] <= 0))) {
             dvdx_e = 0.0;
           } else {
-            dvdx_e = (((vn[jj * LEN + (ji + 1)] - vn[jj * LEN + ji]) / (e1v[jj * LEN + ji] + e1v[jj * LEN + (ji + 1)])) * (((hv[jj * LEN + ji] + sshn_v[jj * LEN + ji]) + hv[jj * LEN + (ji + 1)]) + sshn_v[jj * LEN + (ji + 1)]));
+            dvdx_e = (((vn_buffer[(ji + 1)] - vn_buffer[ji]) / (e1v_buffer[ji] + e1v_buffer[(ji + 1)])) * (((hv_buffer[ji] + sshn_v_buffer[ji]) + hv_buffer[(ji + 1)]) + sshn_v_buffer[(ji + 1)]));
           }
-          vis = (((dvdy_n - dvdy_s) * e1v[jj * LEN + ji]) + (((dvdx_e - dvdx_w) * e2v[jj * LEN + ji]) * 0.5));
+          vis = (((dvdy_n - dvdy_s) * e1v_buffer[ji]) + (((dvdx_e - dvdx_w) * e2v_buffer[ji]) * 0.5));
           vis = (visc * vis);
-          cor = (-(((0.5 * (((2. * omega) * sin((gphiv[jj * LEN + ji] * d2r))) * (u_ec + u_wc))) * e12v[jj * LEN + ji]) * (hv[jj * LEN + ji] + sshn_v[jj * LEN + ji])));
-          hpg = (-(((g * (hv[jj * LEN + ji] + sshn_v[jj * LEN + ji])) * e1v[jj * LEN + ji]) * (sshn[(jj + 1) * LEN + ji] - sshn[jj * LEN + ji])));
-          va[jj * LEN + ji] = ((((vn[jj * LEN + ji] * (hv[jj * LEN + ji] + sshn_v[jj * LEN + ji])) + ((rdt * (((adv + vis) + cor) + hpg)) / e12v[jj * LEN + ji])) / (hv[jj * LEN + ji] + ssha_v[jj * LEN + ji])) / (1.0 + (cbfr * rdt)));
+          cor = (-(((0.5 * (((2. * omega) * sin((gphiv_buffer[ji] * d2r))) * (u_ec + u_wc))) * e12v_buffer[ji]) * (hv_buffer[ji] + sshn_v_buffer[ji])));
+          hpg = (-(((g * (hv_buffer[ji] + sshn_v_buffer[ji])) * e1v_buffer[ji]) * (sshn_nextrow[ji] - sshn_buffer[ji])));
+          va_buffer[ji] = ((((vn_buffer[ji] * (hv_buffer[ji] + sshn_v_buffer[ji])) + ((rdt * (((adv + vis) + cor) + hpg)) / e12v_buffer[ji])) / (hv_buffer[ji] + ssha_v_buffer[ji])) / (1.0 + (cbfr * rdt)));
       }
+
+      for (int ji = xstart; ji <= xstop; ji++){
+        va[jj * LEN + ji] = va_buffer[ji];
+      }
+
   }
 }
 
@@ -430,24 +893,49 @@ __kernel void next_sshu_code(
   const __global double * restrict e12t,
   const __global double * restrict e12u
   ){
-  double rtmp1;
+  // Create buffers for burst copies
+  double sshn_u_buffer[LEN];
+  double sshn_buffer[LEN];
+  double e12t_buffer[LEN];
+  double e12u_buffer[LEN];
+  int tmask_buffer[LEN];
+
   for (int jj = ystart; jj <= ystop; jj++){
+
+      // Burst data reads
       for (int ji = xstart; ji <= xstop; ji++){
-          if (((tmask[jj * LEN + ji] + tmask[jj * LEN + (ji + 1)]) <= 0)) {
+        sshn_buffer[ji] = sshn[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        tmask_buffer[ji] = tmask[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        e12t_buffer[ji] = e12t[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        e12u_buffer[ji] = e12u[jj * LEN + ji];
+      }
+
+      for (int ji = xstart; ji <= xstop; ji++){
+          if (((tmask_buffer[ji] + tmask_buffer[(ji + 1)]) <= 0)) {
             continue;
           }
-          if (((tmask[jj * LEN + ji] * tmask[jj * LEN + (ji + 1)]) > 0)) {
-            rtmp1 = ((e12t[jj * LEN + ji] * sshn[jj * LEN + ji]) + (e12t[jj * LEN + (ji + 1)] * sshn[jj * LEN + (ji + 1)]));
-            sshn_u[jj * LEN + ji] = ((0.5 * rtmp1) / e12u[jj * LEN + ji]);
+          if (((tmask_buffer[ji] * tmask_buffer[(ji + 1)]) > 0)) {
+            double rtmp1 = ((e12t_buffer[ji] * sshn_buffer[ji]) + (e12t_buffer[(ji + 1)] * sshn_buffer[(ji + 1)]));
+            sshn_u_buffer[ji] = ((0.5 * rtmp1) / e12u_buffer[ji]);
           } else {
-            if ((tmask[jj * LEN + ji] <= 0)) {
-              sshn_u[jj * LEN + ji] = sshn[jj * LEN + (ji + 1)];
+            if ((tmask_buffer[ji] <= 0)) {
+              sshn_u_buffer[ji] = sshn_buffer[(ji + 1)];
             } else {
               if ((tmask[jj * LEN + (ji + 1)] <= 0)) {
-                sshn_u[jj * LEN + ji] = sshn[jj * LEN + ji];
+                sshn_u_buffer[ji] = sshn_buffer[ji];
               }
             }
           }
+      }
+      // Burst data write
+      for (int ji = xstart; ji <= xstop; ji++){
+        sshn_u[jj * LEN + ji] = sshn_u_buffer[ji];
       }
   }
 }
@@ -466,24 +954,65 @@ __kernel void next_sshv_code(
   const __global double * restrict e12t,
   const __global double * restrict e12v
   ){
-  double rtmp1;
+  // Create buffers for burst copies
+  double sshn_v_buffer[LEN];
+  double sshn_buffer[LEN];
+  double e12t_buffer[LEN];
+  double e12v_buffer[LEN];
+  int tmask_buffer[LEN];
+
+  double sshn_nextrow[LEN];
+  int tmask_nextrow[LEN];
+  double e12t_nextrow[LEN];
+
   for (int jj = ystart; jj <= ystop; jj++){
+
+      // Burst data reads
       for (int ji = xstart; ji <= xstop; ji++){
-          if (((tmask[jj * LEN + ji] + tmask[(jj + 1) * LEN + ji]) <= 0)) {
+        sshn_buffer[ji] = sshn[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        tmask_buffer[ji] = tmask[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        e12t_buffer[ji] = e12t[jj * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        e12v_buffer[ji] = e12v[jj * LEN + ji];
+      }
+
+      for (int ji = xstart; ji <= xstop; ji++){
+        sshn_nextrow[ji] = sshn[(jj+1) * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        tmask_nextrow[ji] = tmask[(jj+1) * LEN + ji];
+      }
+      for (int ji = xstart; ji <= xstop; ji++){
+        e12t_nextrow[ji] = e12t[(jj+1) * LEN + ji];
+      }
+        
+
+      for (int ji = xstart; ji <= xstop; ji++){
+          if (((tmask_buffer[ji] + tmask_nextrow[ji]) <= 0)) {
             continue;
           }
-          if (((tmask[jj * LEN + ji] * tmask[(jj + 1) * LEN + ji]) > 0)) {
-            rtmp1 = ((e12t[jj * LEN + ji] * sshn[jj * LEN + ji]) + (e12t[(jj + 1) * LEN + ji] * sshn[(jj + 1) * LEN + ji]));
-            sshn_v[jj * LEN + ji] = ((0.5 * rtmp1) / e12v[jj * LEN + ji]);
+          if (((tmask_buffer[ji] * tmask_nextrow[ji]) > 0)) {
+            double rtmp1 = ((e12t_buffer[ji] * sshn_buffer[ji]) + (e12t_nextrow[ji] * sshn_nextrow[ji]));
+            sshn_v_buffer[ji] = ((0.5 * rtmp1) / e12v_buffer[ji]);
           } else {
-            if ((tmask[jj * LEN + ji] <= 0)) {
-              sshn_v[jj * LEN + ji] = sshn[(jj + 1) * LEN + ji];
+            if ((tmask_buffer[ji] <= 0)) {
+              sshn_v_buffer[ji] = sshn_nextrow[ji];
             } else {
-              if ((tmask[(jj + 1) * LEN + ji] <= 0)) {
-                sshn_v[jj * LEN + ji] = sshn[jj * LEN + ji];
+              if ((tmask_nextrow[ji] <= 0)) {
+                sshn_v_buffer[ji] = sshn_buffer[ji];
               }
             }
           }
+      }
+
+      // Burst data write
+      for (int ji = xstart; ji <= xstop; ji++){
+        sshn_v[jj * LEN + ji] = sshn_v_buffer[ji];
       }
   }
 }

--- a/benchmarks/nemo/nemolite2d/manual_versions/psykal_opencl/xilinx.cfg
+++ b/benchmarks/nemo/nemolite2d/manual_versions/psykal_opencl/xilinx.cfg
@@ -2,22 +2,20 @@
 # compiler about multiple synthesis and placement options when building
 # the FPGA kernels.
 
-[connectivity]
+# [connectivity]
 # Create 2 CU of the given kernels
-#nk=continuity_code:2
-#nk=momentum_u_code:2
-#nk=momentum_v_code:2
-#nk=bc_ssh_code:2
-#nk=bc_solid_u_code:2
-#nk=bc_solid_v_code:2
-#nk=bc_flather_u_code:2
-#nk=bc_flather_v_code:2
-#nk=field_copy_code:2
-#nk=next_sshu_code:2
-#nk=next_sshv_code:2
+# nk=continuity_code:2
+# nk=momentum_u_code:2
+# nk=momentum_v_code:2
+# nk=bc_ssh_code:2
+# nk=bc_solid_u_code:2
+# nk=bc_solid_v_code:2
+# nk=bc_flather_u_code:2
+# nk=bc_flather_v_code:2
+# nk=field_copy_code:2
+# nk=next_sshu_code:2
+# nk=next_sshv_code:2
 
-
-[hls]
 # Assign CUs to different SLRs
 # slr=momentum_u_code_1:SLR0
 # slr=momentum_u_code_2:SLR0
@@ -33,12 +31,14 @@
 # slr=bc_flather_v_code_1:SLR2
 # slr=bc_flather_v_code_2:SLR2
 
-# Create an individual M_AXI interface per device_ptr buffer.
-# max_memory_ports=vadd:vadd_1
-
 # Mapping of kernel ports
 # For CU of the same kernel to be symmetrical they need the same SPs
 # sp=momentum_u_code_1.m_axi_gmem:DDR[0]
 # sp=momentum_u_code_2.m_axi_gmem:DDR[0]
 # sp=momentum_v_code_1.m_axi_gmem:DDR[0]
 # sp=momentum_v_code_2.m_axi_gmem:DDR[0]
+
+
+# [hls]
+# Create an individual M_AXI interface per device_ptr buffer.
+# max_memory_ports=continuity_code

--- a/benchmarks/nemo/nemolite2d/psykal/Makefile_gen
+++ b/benchmarks/nemo/nemolite2d/psykal/Makefile_gen
@@ -47,7 +47,7 @@ KERNELS_MULTIPLE = boundary_conditions_0_mod.o \
 # Choose which kernels to use
 KERNELS = ${KERNELS_UNMOD}
 
-.PHONY: nemolite2d nemolite2docl nemolite2dxilinx
+.PHONY: nemolite2d nemolite2docl
 
 all: nemolite2d
 .DEFAULT_GOAL := nemolite2d
@@ -57,18 +57,10 @@ nemolite2d: ${KERNELS} psy.o alg.o
 	$(F90) $(F90FLAGS) -o $@.exe  ${KERNELS} psy.o alg.o ${COMMON_LIB} \
 		${TIMER_LIB} ${INF_LIB} $(LDFLAGS) ${OMPFLAGS}
 
-
 # Build NemoLite2D for OpenCL
 nemolite2docl: ${KERNELS} psy.o alg.o
 	$(F90) $(F90FLAGS) -o nemolite2d.exe  ${KERNELS} psy.o alg.o ${COMMON_LIB} \
 		${TIMER_LIB} ${INF_LIB} $(LDFLAGS) ${OMPFLAGS} ${FORTCL_LIB} -lOpenCL
-
-
-# Build NemoLite2D for OpenCL with Xilinx SDK pre-compiled kernels
-nemolite2dxilinx: ${KERNELS} allkernels.xclbin psy.o alg.o
-	$(F90) $(F90FLAGS) -o $@.exe ${KERNELS} psy.o alg.o ${COMMON_LIB} \
-		${TIMER_LIB} ${INF_LIB} $(LDFLAGS) ${OMPFLAGS} -lOpenCL
-
 
 # Generic rules
 %.o: %.f90
@@ -80,17 +72,15 @@ nemolite2dxilinx: ${KERNELS} allkernels.xclbin psy.o alg.o
 
 %.o: %.mod
 
-# Xilinx Vitis OpenCL kernel compilation
-PLATFORM = xilinx_u200_xdma_201830_2
-EXECUTION_TARGET = sw_emu # Options: sw_emu | hw_emu | hw
+# OpenCL Ahead-of-time kernel compilation
+device_binary: allkernels.cl
+	${OCL_COMPILER} ${OCL_DEVICE_FLAGS} --platform ${FPGA_PLATFORM} \
+		--target ${FPGA_EXECUTION_TARGET} $< -o $<.xo
+	${OCL_LINKER} ${OCL_DEVICE_FLAGS} --platform ${FPGA_PLATFORM} \
+		--target ${FPGA_EXECUTION_TARGET} $<.xo -o $@.xclbin
 
-%.xclbin: %.cl
-	# Compile to a .xo file
-	v++ --compile --platform ${PLATFORM} --target ${EXECUTION_TARGET} \
-		$< -o $<.xo
-	# Link to create a Xilinx FPGA bianry container (.xclbin)
-	v++ --link --platform ${PLATFORM} --target ${EXECUTION_TARGET} \
-		${PROFILING_FLAGS} $<.xo -o $@
+device_binary_nohup:
+	nohup make device_binary > nohup.out &
 
 # If we need a .f90 file that doesn't exist then it must be a kernel.
 # Create a link to the required file...
@@ -99,7 +89,6 @@ EXECUTION_TARGET = sw_emu # Options: sw_emu | hw_emu | hw
 
 clean:
 	rm -f *.o *.mod *_opt_report.txt
-
 
 # OpenCL Execution helpers
 run_opencl_jit:

--- a/benchmarks/nemo/nemolite2d/psykal/Makefile_gen
+++ b/benchmarks/nemo/nemolite2d/psykal/Makefile_gen
@@ -47,7 +47,7 @@ KERNELS_MULTIPLE = boundary_conditions_0_mod.o \
 # Choose which kernels to use
 KERNELS = ${KERNELS_UNMOD}
 
-.PHONY: nemolite2d nemolite2docl
+.PHONY: nemolite2d nemolite2docl device_binary device_binary_nohup
 
 all: nemolite2d
 .DEFAULT_GOAL := nemolite2d

--- a/benchmarks/nemo/nemolite2d/psykal/Makefile_gen
+++ b/benchmarks/nemo/nemolite2d/psykal/Makefile_gen
@@ -72,7 +72,8 @@ nemolite2docl: ${KERNELS} psy.o alg.o
 
 %.o: %.mod
 
-# OpenCL Ahead-of-time kernel compilation
+# OpenCL Ahead-of-time kernel compilation: this target will use the Xilinx standard
+# suffixes for object (.xo) and binary (.xclbin) files
 device_binary: allkernels.cl
 	${OCL_COMPILER} ${OCL_DEVICE_FLAGS} --platform ${FPGA_PLATFORM} \
 		--target ${FPGA_EXECUTION_TARGET} $< -o $<.xo

--- a/benchmarks/nemo/nemolite2d/psykal/psyclone_scripts/acc_transform.py
+++ b/benchmarks/nemo/nemolite2d/psykal/psyclone_scripts/acc_transform.py
@@ -4,6 +4,7 @@ function via the -s option. Performs OpenACC transformations. '''
 from psyclone.psyGen import TransInfo
 from psyclone.psyir.nodes import Loop
 
+
 def trans(psy):
     ''' Take the supplied psy object, apply OpenACC transformations
     to the schedule of invoke_0 and return the new psy object '''
@@ -22,8 +23,7 @@ def trans(psy):
     # in the schedule
     for child in schedule.children:
         if isinstance(child, Loop):
-            newschedule, _ = loop_trans.apply(child, {"collapse": 2})
-            schedule = newschedule
+            loop_trans.apply(child, {"collapse": 2})
 
     # Put all of the loops in a single parallel region
     parallel_trans.apply(schedule)

--- a/benchmarks/nemo/nemolite2d/psykal/psyclone_scripts/ocl_transform.py
+++ b/benchmarks/nemo/nemolite2d/psykal/psyclone_scripts/ocl_transform.py
@@ -13,6 +13,7 @@ MOVE_BOUNDARIES = True
 XILINX_CONFIG_FILE = False
 TILING = 64
 
+
 def trans(psy):
     ''' Transform the schedule for OpenCL generation '''
 
@@ -58,7 +59,6 @@ def trans(psy):
         else:
             kern.set_opencl_options({'local_size': TILING})
 
-
     # Transform invoke to OpenCL
     cltrans.apply(schedule)
 
@@ -67,18 +67,18 @@ def trans(psy):
         path = Config.get().kernel_output_dir
         with open(os.path.join(path, "xilinx.cfg"), "w") as cfgfile:
             cfgfile.write("# Xilinx FPGA configuration file\n")
-            #cfgfile.write("[connectivity]\n")
-            #cfgfile.write("# Create 2 CU of the given kernels\n")
-            #cfgfile.write("nk=continuity_code:2\n")
-            #cfgfile.write("nk=momentum_u_code:2\n")
-            #cfgfile.write("nk=momentum_v_code:2\n")
-            #cfgfile.write("nk=bc_ssh_code:2\n")
+            # cfgfile.write("[connectivity]\n")
+            # cfgfile.write("# Create 2 CU of the given kernels\n")
+            # cfgfile.write("nk=continuity_code:2\n")
+            # cfgfile.write("nk=momentum_u_code:2\n")
+            # cfgfile.write("nk=momentum_v_code:2\n")
+            # cfgfile.write("nk=bc_ssh_code:2\n")
 
-            #cfgfile.write("\n[hls]\n")
-            #cfgfile.write("# Assign CUs to different SLRs\n")
-            #cfgfile.write("slr=momentum_u_code_1:SLR0\n")
-            #cfgfile.write("slr=momentum_u_code_2:SLR0\n")
-            #cfgfile.write("slr=momentum_v_code_1:SLR2\n")
-            #cfgfile.write("slr=momentum_v_code_2:SLR2\n")
+            # cfgfile.write("\n[hls]\n")
+            # cfgfile.write("# Assign CUs to different SLRs\n")
+            # cfgfile.write("slr=momentum_u_code_1:SLR0\n")
+            # cfgfile.write("slr=momentum_u_code_2:SLR0\n")
+            # cfgfile.write("slr=momentum_v_code_1:SLR2\n")
+            # cfgfile.write("slr=momentum_v_code_2:SLR2\n")
 
     return psy

--- a/benchmarks/nemo/nemolite2d/psykal/psyclone_scripts/ocl_transform.py
+++ b/benchmarks/nemo/nemolite2d/psykal/psyclone_scripts/ocl_transform.py
@@ -2,31 +2,84 @@
 function via the -s option. Applies OpenCL to the Schedule so
 that PSyclone will generate an OpenCL PSy layer. '''
 
+import os
 from psyclone.psyGen import TransInfo
 from psyclone.domain.gocean.transformations import \
     GOMoveIterationBoundariesInsideKernelTrans
+from psyclone.configuration import Config
 
+FUCTIONAL_PARALLELISM = False
+MOVE_BOUNDARIES = True
+XILINX_CONFIG_FILE = False
+TILING = 64
 
 def trans(psy):
     ''' Transform the schedule for OpenCL generation '''
+
+    # Import transformations
     tinfo = TransInfo()
     globaltrans = tinfo.get_trans_name('KernelGlobalsToArguments')
     move_boundaries_trans = GOMoveIterationBoundariesInsideKernelTrans()
     cltrans = tinfo.get_trans_name('OCLTrans')
 
-    # Get the invoke
+    # Get the invoke routine
     schedule = psy.invokes.get('invoke_0').schedule
+
+    # Map the kernels by their name to different OpenCL queues. The multiple
+    # command queues can be executed concurrently while each command queue
+    # executes in-order its kernels. This provides functional parallelism
+    # when kernels don't have dependencies between them.
+    qmap = {
+        'continuity_code': 1,
+        'momentum_u_code': 2,
+        'momentum_v_code': 3,
+        'bc_ssh_code': 1,
+        'bc_solid_u_code': 2,
+        'bc_solid_v_code': 3,
+        'bc_flather_u_code': 2,
+        'bc_flather_v_code': 3,
+        # Needs a barrier here (currently added manually)
+        'field_copy_code': 1,
+        'next_sshu_code': 1,
+        'next_sshv_code': 1
+        }
 
     # Remove global variables from inside each kernel, pass the boundary
     # values as arguments to the kernel and set the OpenCL work size to 64,
     # which is required for performance (with OpenCL < 1.2 this requires
     # the resulting application to be executed with DL_ESM_ALIGNMENT=64)
     for kern in schedule.kernels():
+        print(kern.name)
         globaltrans.apply(kern)
-        move_boundaries_trans.apply(kern)
-        kern.set_opencl_options({'local_size': 64})
+        if MOVE_BOUNDARIES:
+            move_boundaries_trans.apply(kern)
+        if FUCTIONAL_PARALLELISM:
+            kern.set_opencl_options({'local_size': TILING,
+                                     'queue_number': qmap[kern.name]})
+        else:
+            kern.set_opencl_options({'local_size': TILING})
+
 
     # Transform invoke to OpenCL
     cltrans.apply(schedule)
+
+    if XILINX_CONFIG_FILE:
+        # Create a Xilinx Compiler Configuration file
+        path = Config.get().kernel_output_dir
+        with open(os.path.join(path, "xilinx.cfg"), "w") as cfgfile:
+            cfgfile.write("# Xilinx FPGA configuration file\n")
+            #cfgfile.write("[connectivity]\n")
+            #cfgfile.write("# Create 2 CU of the given kernels\n")
+            #cfgfile.write("nk=continuity_code:2\n")
+            #cfgfile.write("nk=momentum_u_code:2\n")
+            #cfgfile.write("nk=momentum_v_code:2\n")
+            #cfgfile.write("nk=bc_ssh_code:2\n")
+
+            #cfgfile.write("\n[hls]\n")
+            #cfgfile.write("# Assign CUs to different SLRs\n")
+            #cfgfile.write("slr=momentum_u_code_1:SLR0\n")
+            #cfgfile.write("slr=momentum_u_code_2:SLR0\n")
+            #cfgfile.write("slr=momentum_v_code_1:SLR2\n")
+            #cfgfile.write("slr=momentum_v_code_2:SLR2\n")
 
     return psy

--- a/benchmarks/nemo/nemolite2d/psykal/psyclone_scripts/ocl_transform.py
+++ b/benchmarks/nemo/nemolite2d/psykal/psyclone_scripts/ocl_transform.py
@@ -8,11 +8,25 @@ from psyclone.domain.gocean.transformations import \
     GOMoveIterationBoundariesInsideKernelTrans
 from psyclone.configuration import Config
 
-FUCTIONAL_PARALLELISM = True
-MOVE_BOUNDARIES = True
-XILINX_CONFIG_FILE = False
-TILING = 64
 
+# Global variables to configure the PSyclone OpenCL generation:
+
+# If FUCTIONAL_PARALLELISM is enabled the kernels will be dispatched to
+# multiple command queues and run asynchronously when possible, otherwise
+# all kernels will be run in-order in command queue number 1.
+FUCTIONAL_PARALLELISM = True
+
+# If MOVE_BOUNDARIES is True (mandatory for now) the start and stop boundaries
+# of each loop will be moved from the PSy-layer to inside the kernel.
+MOVE_BOUNDARIES = True
+
+# If XILINX_CONFIG_FILE is True, this script will also generate a Xiling .cfg
+# configuration file in the output directory.
+XILINX_CONFIG_FILE = False
+
+# The TILING parameter sets the number of kernel iterations that will be run
+# together by a single kernel execution.
+TILING = 64
 
 def trans(psy):
     ''' Transform the schedule for OpenCL generation '''

--- a/benchmarks/nemo/nemolite2d/psykal/psyclone_scripts/ocl_transform.py
+++ b/benchmarks/nemo/nemolite2d/psykal/psyclone_scripts/ocl_transform.py
@@ -8,7 +8,7 @@ from psyclone.domain.gocean.transformations import \
     GOMoveIterationBoundariesInsideKernelTrans
 from psyclone.configuration import Config
 
-FUCTIONAL_PARALLELISM = False
+FUCTIONAL_PARALLELISM = True
 MOVE_BOUNDARIES = True
 XILINX_CONFIG_FILE = False
 TILING = 64
@@ -38,7 +38,6 @@ def trans(psy):
         'bc_solid_v_code': 3,
         'bc_flather_u_code': 2,
         'bc_flather_v_code': 3,
-        # Needs a barrier here (currently added manually)
         'field_copy_code': 1,
         'next_sshu_code': 1,
         'next_sshv_code': 1

--- a/benchmarks/nemo/nemolite2d/psykal/psyclone_scripts/omp_transform.py
+++ b/benchmarks/nemo/nemolite2d/psykal/psyclone_scripts/omp_transform.py
@@ -6,6 +6,7 @@ from psyclone.psyGen import TransInfo
 from psyclone.psyir.nodes import Loop
 from psyclone.configuration import Config
 
+
 def trans(psy):
     ''' Transformation entry point '''
     config = Config.get()
@@ -13,27 +14,26 @@ def trans(psy):
     parallel_loop_trans = tinfo.get_trans_name('GOceanOMPParallelLoopTrans')
     loop_trans = tinfo.get_trans_name('GOceanOMPLoopTrans')
     parallel_trans = tinfo.get_trans_name('OMPParallelTrans')
-    inline_trans = tinfo.get_trans_name('KernelModuleInline')
+    module_inline_trans = tinfo.get_trans_name('KernelModuleInline')
 
     schedule = psy.invokes.get('invoke_0').schedule
 
     # Inline all kernels in this Schedule
     for kernel in schedule.kernels():
-        inline_trans.apply(kernel)
+        module_inline_trans.apply(kernel)
 
     # Apply the OpenMPLoop transformation to every child in the schedule or
     # OpenMPParallelLoop to every Loop if it has distributed memory.
     for child in schedule.children:
         if config.distributed_memory:
             if isinstance(child, Loop):
-                schedule, _ = parallel_loop_trans.apply(child)
+                parallel_loop_trans.apply(child)
         else:
-            schedule, _ = loop_trans.apply(child)
-
+            loop_trans.apply(child)
 
     if not config.distributed_memory:
         # If it is not distributed memory, enclose all of these loops
         # within a single OpenMP PARALLEL region
-        schedule, _ = parallel_trans.apply(schedule.children)
+        parallel_trans.apply(schedule.children)
 
     return psy

--- a/benchmarks/nemo/nemolite2d/psykal/psyclone_scripts/serial_transform.py
+++ b/benchmarks/nemo/nemolite2d/psykal/psyclone_scripts/serial_transform.py
@@ -3,6 +3,7 @@ via the -s option. This script module-inline all kernels in the PSy-layer.'''
 
 from psyclone.psyGen import TransInfo
 
+
 def trans(psy):
     ''' Transformation script entry function '''
 

--- a/compiler_setup/xilinx.sh
+++ b/compiler_setup/xilinx.sh
@@ -1,10 +1,10 @@
 # Environment variables for OpenCL for Xilinx FPGAs
 
-export PLATFORM=xilinx_u200_xdma_201830_2
-export EXECUTION_TARGET=hw # Options: sw_emu | hw_emu | hw
-export XILINX_FLAGS="--jobs 8 -O2 --report_level 1 --config xilinx.cfg"
-export OCL_COMPILER="v++ --compile --platform ${PLATFORM} --target ${EXECUTION_TARGET} ${XILINX_FLAGS}"
-export OCL_LINKER="v++ --link --platform ${PLATFORM} --target ${EXECUTION_TARGET} ${XILINX_FLAGS}"
+export FPGA_PLATFORM=xilinx_u200_xdma_201830_2
+export FPGA_EXECUTION_TARGET=hw # Options: sw_emu | hw_emu | hw
+export OCL_DEVICE_FLAGS="-O2 --report_level 1 --config xilinx.cfg"
+export OCL_COMPILER="v++ --compile"
+export OCL_LINKER="v++ --link"
 
 # Host compiler flags
 export OPENCL_LIBS="-lOpenCL"

--- a/compiler_setup/xilinx.sh
+++ b/compiler_setup/xilinx.sh
@@ -12,7 +12,7 @@ export OPENCL_INCLUDE=""
 
 
 # Configurable parameters
-echo "Set EXECUTION_TARGET to switch the target platform:"
+echo "Set FPGA_EXECUTION_TARGET to switch the target platform:"
 echo "    sw_emu - for software emulation"
 echo "    hw_emu - for hardware emulation"
 echo "    hw - for FPGA execution. (default)"


### PR DESCRIPTION
This PR improves the PSyclone OpenCL script to generate FPGA code and the OpenCL tasks implementation. This is an effort towards #69, but still more improvements are necessary to achieve an acceptable performance. (the best performance in this PR is still x15 slower than a single core CPU, it still uses only 1 memory bank and bundles all the kernel accesses in a single port)

![image](https://user-images.githubusercontent.com/1449555/119003939-0a083b80-b986-11eb-8787-ebd2a1b7b425.png)
