### PR TITLE
Psykal OpenMP taskloop implementation of NemoLite2D

### DIFF
--- a/benchmarks/nemo/nemolite2d/manual_versions/psykal_serial/Makefile
+++ b/benchmarks/nemo/nemolite2d/manual_versions/psykal_serial/Makefile
@@ -2,7 +2,7 @@
 #
 # F90       - How to invoke the Fortran compiler
 # F90FLAGS  - Flags to pass to the Fortran compiler
-# OMPFLAGS  - Flags for compiling with OpenMP
+# OMPFLAGS  - Flags needed for linking dl_timer
 # AR        - Command to use when creating an archive (.a)
 
 .PHONY: all nemolite2d nemolite2d_align nemolite2d_cont_only nemolite2d_nodiv nemolite2d_preload nemolite2d_alignall nemolite2d_nopeel nemolite2d_8arrays
@@ -89,6 +89,7 @@ clean:
 	rm -f *.o *.mod *.MOD *~
 
 libclean:
+	${MAKE} -C ${COMMON_DIR} allclean
 	${MAKE} -C ${INF_DIR} distclean
 	${MAKE} -C ${TIMER_DIR} allclean
 

--- a/benchmarks/nemo/nemolite2d/psykal/Makefile
+++ b/benchmarks/nemo/nemolite2d/psykal/Makefile
@@ -87,7 +87,7 @@ nemolite2d_omp: serial_libs nemolite2d_alg.f90 psyclone_scripts/omp_transform.py
 # OpenMP task PSyclone code-generation of NemoLite2D
 nemolite2d_ompt: serial_libs nemolite2d_alg.f90 psyclone_scripts/omp_task_transform.py
 	@echo "Generating NemoLite2D with OpenMP using omp_task_transform.py"; rm -rf $@; mkdir -p $@
-	${PSYCLONE} -nodm -s psyclone_scripts/omp_task_transform.py \
+	${PSYCLONE} -nodm -s ./psyclone_scripts/omp_task_transform.py \
 		-oalg $@/alg.f90 -opsy $@/psy.f90 nemolite2d_alg.f90
 	# Each generated folder needs its purposely built inf_lib and timer_lib
 	cp ${INF_LIB} $@/.
@@ -99,7 +99,7 @@ nemolite2d_ompt: serial_libs nemolite2d_alg.f90 psyclone_scripts/omp_task_transf
 
 nemolite2d_ompt_mpi: parallel_libs nemolite2d_alg.f90 psyclone_scripts/omp_task_transform.py
 	@echo "Generating NemoLite2D with OpenMP tasks and MPI"; rm -rf $@; mkdir -p $@
-	${PSYCLONE} -dm -s psyclone_scripts/omp_task_transform.py \
+	${PSYCLONE} -dm -s ./psyclone_scripts/omp_task_transform.py \
 	   	-oalg $@/alg.f90 -opsy $@/psy.f90 nemolite2d_alg.f90
 	# Each generated folder needs its purposely built inf_lib and timer_lib
 	cp ${INF_LIB} $@/.

--- a/benchmarks/nemo/nemolite2d/psykal/Makefile
+++ b/benchmarks/nemo/nemolite2d/psykal/Makefile
@@ -44,7 +44,8 @@ COMMON_LIB = ${COMMON_DIR}/nemolite2d_common.a
 
 # The targets that this Makefile supports
 .PHONY: all nemolite2d_serial nemolite2d_omp nemolite2d_mpi nemolite2d_acc \
-	nemolite2d_hybrid nemolite2d_ocl nemolite2d_mpiocl nemolite2d_ompt
+	nemolite2d_hybrid nemolite2d_ocl nemolite2d_mpiocl nemolite2d_ompt \
+	nemolite2d_ompt_mpi
 
 # We don't include the OpenACC or OpenCL targets here as they
 # have specialist compiler requirements so we require the user
@@ -95,6 +96,18 @@ nemolite2d_ompt: serial_libs nemolite2d_alg.f90 psyclone_scripts/omp_task_transf
 	cp Makefile_gen $@/Makefile
 	cd $@ && make nemolite2d
 	@echo "OpenMP task version prepared."
+
+nemolite2d_ompt_mpi: parallel_libs nemolite2d_alg.f90 psyclone_scripts/omp_task_transform.py
+	@echo "Generating NemoLite2D with OpenMP tasks and MPI"; rm -rf $@; mkdir -p $@
+	${PSYCLONE} -dm -s psyclone_scripts/omp_task_transform.py \
+	   	-oalg $@/alg.f90 -opsy $@/psy.f90 nemolite2d_alg.f90
+	# Each generated folder needs its purposely built inf_lib and timer_lib
+	cp ${INF_LIB} $@/.
+	cp ${TIMER_LIB_DM} $@/libdl_timer.a
+	cp namelist $@/.
+	cp Makefile_gen $@/Makefile
+	cd $@ && make nemolite2d
+	@echo "Task + MPI version prepared."
 
 # MPI PSyclone code-generation of NemoLite2D
 nemolite2d_mpi: parallel_libs nemolite2d_alg.f90 psyclone_scripts/serial_transform.py

--- a/benchmarks/nemo/nemolite2d/psykal/Makefile
+++ b/benchmarks/nemo/nemolite2d/psykal/Makefile
@@ -44,7 +44,7 @@ COMMON_LIB = ${COMMON_DIR}/nemolite2d_common.a
 
 # The targets that this Makefile supports
 .PHONY: all nemolite2d_serial nemolite2d_omp nemolite2d_mpi nemolite2d_acc \
-	nemolite2d_hybrid nemolite2d_ocl nemolite2d_mpiocl
+	nemolite2d_hybrid nemolite2d_ocl nemolite2d_mpiocl nemolite2d_ompt
 
 # We don't include the OpenACC or OpenCL targets here as they
 # have specialist compiler requirements so we require the user
@@ -82,6 +82,19 @@ nemolite2d_omp: serial_libs nemolite2d_alg.f90 psyclone_scripts/omp_transform.py
 	cp Makefile_gen $@/Makefile
 	cd $@ && make nemolite2d
 	@echo "OpenMP version prepared."
+
+# OpenMP task PSyclone code-generation of NemoLite2D
+nemolite2d_ompt: serial_libs nemolite2d_alg.f90 psyclone_scripts/omp_task_transform.py
+	@echo "Generating NemoLite2D with OpenMP using omp_task_transform.py"; rm -rf $@; mkdir -p $@
+	${PSYCLONE} -nodm -s psyclone_scripts/omp_task_transform.py \
+		-oalg $@/alg.f90 -opsy $@/psy.f90 nemolite2d_alg.f90
+	# Each generated folder needs its purposely built inf_lib and timer_lib
+	cp ${INF_LIB} $@/.
+	cp ${TIMER_LIB} $@/libdl_timer.a
+	cp namelist $@/.
+	cp Makefile_gen $@/Makefile
+	cd $@ && make nemolite2d
+	@echo "OpenMP task version prepared."
 
 # MPI PSyclone code-generation of NemoLite2D
 nemolite2d_mpi: parallel_libs nemolite2d_alg.f90 psyclone_scripts/serial_transform.py

--- a/benchmarks/nemo/nemolite2d/psykal/Makefile_gen
+++ b/benchmarks/nemo/nemolite2d/psykal/Makefile_gen
@@ -93,7 +93,7 @@ clean:
 
 # OpenCL Execution helpers
 run_opencl_jit:
-	FORTCL_KERNELS_FILE=allkernels.cl ./nemolite2d.exe
+	 DL_ESM_ALIGNMENT=64 FORTCL_KERNELS_FILE=allkernels.cl ./nemolite2d.exe
 
 run_xilinx_sw_emu:
 	FORTCL_KERNELS_FILE=allkernels.xclbin XCL_EMULATION_MODE=sw_emu ./nemolite2d.exe

--- a/benchmarks/nemo/nemolite2d/psykal/psyclone_scripts/acc_transform.py
+++ b/benchmarks/nemo/nemolite2d/psykal/psyclone_scripts/acc_transform.py
@@ -13,7 +13,7 @@ def trans(psy):
     loop_trans = tinfo.get_trans_name('ACCLoopTrans')
     enter_data_trans = tinfo.get_trans_name('ACCEnterDataTrans')
     routine_trans = tinfo.get_trans_name('ACCRoutineTrans')
-    glo2arg_trans = tinfo.get_trans_name('KernelGlobalsToArguments')
+    glo2arg_trans = tinfo.get_trans_name('KernelImportsToArguments')
     inline_trans = tinfo.get_trans_name('KernelModuleInline')
 
     invoke = psy.invokes.get('invoke_0')

--- a/benchmarks/nemo/nemolite2d/psykal/psyclone_scripts/ocl_transform.py
+++ b/benchmarks/nemo/nemolite2d/psykal/psyclone_scripts/ocl_transform.py
@@ -5,7 +5,7 @@ that PSyclone will generate an OpenCL PSy layer. '''
 import os
 from psyclone.psyGen import TransInfo
 from psyclone.domain.gocean.transformations import \
-    GOMoveIterationBoundariesInsideKernelTrans
+    GOMoveIterationBoundariesInsideKernelTrans, GOOpenCLTrans
 from psyclone.configuration import Config
 
 
@@ -28,14 +28,15 @@ XILINX_CONFIG_FILE = False
 # together by a single kernel execution.
 TILING = 64
 
+
 def trans(psy):
     ''' Transform the schedule for OpenCL generation '''
 
     # Import transformations
     tinfo = TransInfo()
-    globaltrans = tinfo.get_trans_name('KernelGlobalsToArguments')
+    globaltrans = tinfo.get_trans_name('KernelImportsToArguments')
     move_boundaries_trans = GOMoveIterationBoundariesInsideKernelTrans()
-    cltrans = tinfo.get_trans_name('OCLTrans')
+    cltrans = GOOpenCLTrans()
 
     # Get the invoke routine
     schedule = psy.invokes.get('invoke_0').schedule

--- a/benchmarks/nemo/nemolite2d/psykal/psyclone_scripts/omp_task_transform.py
+++ b/benchmarks/nemo/nemolite2d/psykal/psyclone_scripts/omp_task_transform.py
@@ -74,7 +74,7 @@ def trans(psy):
                 if j >= next_dependence:
                     break
                 if next_dependencies[j] is not None:
-                    if next_dependencies[j] < next_dependence:
+                    if next_dependencies[j] <= next_dependence:
                         next_dependence = next_dependencies[j]
                         next_dependencies[i] = None
                     if next_dependencies[j] > next_dependence:

--- a/benchmarks/nemo/nemolite2d/psykal/psyclone_scripts/omp_task_transform.py
+++ b/benchmarks/nemo/nemolite2d/psykal/psyclone_scripts/omp_task_transform.py
@@ -43,10 +43,10 @@ def trans(psy):
     # don't apply OpenMP transformations to the Halo Exchange operations.
     next_start = 0
     next_end = 0
-    for idx in range(len(schedule.children)):
+    idx = 0
+    for idx, child in enumerate(schedule.children):
         # Loop through through the schedule until we find a non-OpenMP
         # node, and extend the grouping until we do.
-        child = schedule.children[idx]
         if isinstance(child, (OMPTaskloopDirective, OMPTaskwaitDirective)):
             next_end = next_end + 1
         elif not isinstance(child, OMPDirective):
@@ -60,7 +60,7 @@ def trans(psy):
             else:
                 sets.append((next_start, next_end))
                 next_end = idx + 1
-                next_start = idx+1
+                next_start = idx + 1
         else:
             next_end = next_end + 1
     # If currently in a grouping of directives, add it to the list
@@ -80,3 +80,4 @@ def trans(psy):
     for child in schedule.children:
         if isinstance(child, OMPParallelDirective):
             wait_trans.apply(child)
+        child = schedule.children[idx]

--- a/benchmarks/nemo/nemolite2d/psykal/psyclone_scripts/omp_task_transform.py
+++ b/benchmarks/nemo/nemolite2d/psykal/psyclone_scripts/omp_task_transform.py
@@ -80,4 +80,3 @@ def trans(psy):
     for child in schedule.children:
         if isinstance(child, OMPParallelDirective):
             wait_trans.apply(child)
-        child = schedule.children[idx]

--- a/benchmarks/nemo/nemolite2d/psykal/psyclone_scripts/omp_task_transform.py
+++ b/benchmarks/nemo/nemolite2d/psykal/psyclone_scripts/omp_task_transform.py
@@ -1,0 +1,80 @@
+''' Python script intended to be passed to PSyclone's generate()
+function via the -s option. It applies OpenMP to every loop and
+inlines all kernels in the schedule.'''
+
+from psyclone.psyGen import TransInfo
+from psyclone.psyir.nodes import Loop
+from psyclone.configuration import Config
+from psyclone.transformations import OMPParallelTrans, OMPSingleTrans
+from psyclone.transformations import OMPTaskloopTrans, KernelModuleInlineTrans
+from psyclone.psyir.nodes import OMPTaskwaitDirective
+
+
+def trans(psy):
+    '''Transformation entry point'''
+    config = Config.get()
+
+    schedule = psy.invokes.get('invoke_0').schedule
+
+    if config.distributed_memory:
+        print("Distributed memory not yet implemented")
+        quit()
+
+    loop_trans = OMPTaskloopTrans(grainsize=32)
+
+    module_inline_trans = KernelModuleInlineTrans()
+
+    # Inline all kernels in this Schedule
+    for kernel in schedule.kernels():
+        module_inline_trans.apply(kernel)
+
+    next_dependencies = []
+    for child in schedule.children:
+        next_dependencies.append(0)
+
+    i = 0
+
+    for child in schedule.children:
+        next_dependencies[i] = child.forward_dependence()
+        i = i + 1
+
+    i = 0
+    for child in schedule.children:
+        j = 0
+        for child in schedule.children:
+            if child == next_dependencies[i]:
+                next_dependencies[i] = j
+                break
+            j = j + 1
+        i = i + 1
+
+    for i in range(len(next_dependencies)):
+        if next_dependencies[i] is not None:
+            next_dependence = next_dependencies[i]
+            print("next dependence {}".format(next_dependence))
+            for j in range(i+1, next_dependence):
+                if j >= next_dependence:
+                    break
+                if next_dependencies[j] is not None:
+                    if next_dependencies[j] < next_dependence:
+                        next_dependence = next_dependencies[j]
+                        next_dependencies[i] = None
+                    if next_dependencies[j] > next_dependence:
+                        next_dependencies[j] = None
+
+    for child in schedule.children:
+        loop_trans.apply(child)
+    print(next_dependencies)
+    # TODO: Sort out dependencies!
+    for i in range(len(next_dependencies)-1, -1, -1):
+        if next_dependencies[i] is not None:
+            schedule.addchild(OMPTaskwaitDirective(), next_dependencies[i])
+            print("Inserted taskwait at {}".format(next_dependencies[i]))
+
+
+    single_trans = OMPSingleTrans()
+    parallel_trans = OMPParallelTrans()
+    single_trans.apply(schedule.children)
+    parallel_trans.apply(schedule.children)
+
+

--- a/benchmarks/nemo/nemolite2d/psykal/psyclone_scripts/omp_task_transform.py
+++ b/benchmarks/nemo/nemolite2d/psykal/psyclone_scripts/omp_task_transform.py
@@ -1,8 +1,7 @@
 ''' Python script intended to be passed to PSyclone's generate()
-function via the -s option. It applies OpenMP to every loop and
-inlines all kernels in the schedule.'''
+function via the -s option. It applies OpenMP tasking to every loop
+and inlines all kernels in the schedule.'''
 
-from psyclone.psyGen import TransInfo
 from psyclone.psyir.nodes import Loop
 from psyclone.configuration import Config
 from psyclone.transformations import OMPParallelTrans, OMPSingleTrans, \
@@ -10,7 +9,6 @@ from psyclone.transformations import OMPParallelTrans, OMPSingleTrans, \
 from psyclone.psyir.transformations import OMPTaskwaitTrans
 from psyclone.psyir.nodes import OMPTaskloopDirective, OMPTaskwaitDirective, \
                                  OMPDirective, OMPParallelDirective
-from psyclone.psyGen import HaloExchange
 
 
 def trans(psy):
@@ -19,13 +17,10 @@ def trans(psy):
 
     schedule = psy.invokes.get('invoke_0').schedule
 
-
-
     loop_trans = OMPTaskloopTrans(grainsize=32, nogroup=True)
     wait_trans = OMPTaskwaitTrans()
 
     module_inline_trans = KernelModuleInlineTrans()
-
 
     # Inline all kernels in this Schedule
     for kernel in schedule.kernels():
@@ -38,35 +33,50 @@ def trans(psy):
     single_trans = OMPSingleTrans()
     parallel_trans = OMPParallelTrans()
     sets = []
-    if config.distributed_memory:
-        # Find all of the groupings of taskloop and taskwait directives. Each of these
-        # groups needs its own parallel+single regions.
-        next_start = 0
-        next_end = 0
-        for index in range(len(schedule.children)):
-            child = schedule.children[index]
-            if isinstance(child, OMPTaskloopDirective) or isinstance(child, OMPTaskwaitDirective):
-                next_end = next_end + 1
-            elif not isinstance(child, OMPDirective):
-                if next_start == index:
-                    next_end = index + 1
-                    next_start = index + 1
-                else:
-                    sets.append((next_start, next_end))
-                    next_end = index + 1
-                    next_start = index+1
-            else:
-                next_end = next_end + 1
-        if next_start <= index:
-            sets.append((next_start, index+1))
-        sets.reverse()
-        for next_set in sets:
-            single_trans.apply(schedule[next_set[0]:next_set[1]])
-            parallel_trans.apply(schedule[next_set[0]])
-        for child in schedule.children:
-            if isinstance(child, OMPParallelDirective):
-                wait_trans.apply(child)
-    else:
+    if not config.distributed_memory:
         single_trans.apply(schedule.children)
         parallel_trans.apply(schedule.children)
         wait_trans.apply(schedule.children[0])
+        return
+    # Find all of the groupings of taskloop and taskwait directives. Each of
+    # these groups needs its own parallel+single regions. This makes sure we
+    # don't apply OpenMP transformations to the Halo Exchange operations.
+    next_start = 0
+    next_end = 0
+    for idx in range(len(schedule.children)):
+        # Loop through through the schedule until we find a non-OpenMP
+        # node, and extend the grouping until we do.
+        child = schedule.children[idx]
+        if isinstance(child, (OMPTaskloopDirective, OMPTaskwaitDirective)):
+            next_end = next_end + 1
+        elif not isinstance(child, OMPDirective):
+            # If we find a non OpenMP directive, if we're currently in a
+            # grouping of OpenMP directives then we stop, and add it to
+            # the set of groupings. Otherwise we just skip over this
+            # node.
+            if next_start == idx:
+                next_end = idx + 1
+                next_start = idx + 1
+            else:
+                sets.append((next_start, next_end))
+                next_end = idx + 1
+                next_start = idx+1
+        else:
+            next_end = next_end + 1
+    # If currently in a grouping of directives, add it to the list
+    # of groupings
+    if next_start <= idx:
+        sets.append((next_start, idx+1))
+    # Start from the last grouping to keep indexing correct,
+    # so reverse the ordering
+    sets.reverse()
+    # For each of the groupings of OpenMP directives, surround them
+    # with an OpenMP Single and an OpenMP Parallel directive set.
+    for next_set in sets:
+        single_trans.apply(schedule[next_set[0]:next_set[1]])
+        parallel_trans.apply(schedule[next_set[0]])
+    # Finally, we loop over the OMPParallelDirectives, and apply the
+    # OMPTaskWaitTrans to ensure correctness.
+    for child in schedule.children:
+        if isinstance(child, OMPParallelDirective):
+            wait_trans.apply(child)

--- a/benchmarks/nemo/nemolite2d/psykal/psyclone_scripts/omp_task_transform.py
+++ b/benchmarks/nemo/nemolite2d/psykal/psyclone_scripts/omp_task_transform.py
@@ -70,4 +70,3 @@ def trans(psy):
         single_trans.apply(schedule.children)
         parallel_trans.apply(schedule.children)
         wait_trans.apply(schedule.children[0])
-

--- a/benchmarks/nemo/nemolite2d/psykal/psyclone_scripts/omp_task_transform.py
+++ b/benchmarks/nemo/nemolite2d/psykal/psyclone_scripts/omp_task_transform.py
@@ -51,7 +51,6 @@ def trans(psy):
     for i in range(len(next_dependencies)):
         if next_dependencies[i] is not None:
             next_dependence = next_dependencies[i]
-            print("next dependence {}".format(next_dependence))
             for j in range(i+1, next_dependence):
                 if j >= next_dependence:
                     break
@@ -69,7 +68,6 @@ def trans(psy):
     for i in range(len(next_dependencies)-1, -1, -1):
         if next_dependencies[i] is not None:
             schedule.addchild(OMPTaskwaitDirective(), next_dependencies[i])
-            print("Inserted taskwait at {}".format(next_dependencies[i]))
 
 
     single_trans = OMPSingleTrans()


### PR DESCRIPTION
I have implemented a script using the `OMPTaskloopTrans` and `OMPTaskwaitDirective`.

I think this correctly captures all of the dependencies, while minimising the number of statements required to do this. This is done by lines 31-62 of the code, and lines 68-70.

What this does, is use `forward_dependence` to find the next dependency for each loop, and find the index of this dependency in the schedule. It then loops through these dependencies. If there are other dependencies between X and its dependent which are covered by the creation of such a dependence, it is deleted (line 61-62). If another dependence will be created sooner, this dependence is removed. 

I'm sure there are some cases which this doesn't entirely minimise, so if anyone can think of those examples (or ways to implement tests of these?). I think this still handles a case such as:
```
[ 5, 4, 3, None, None, None, None, ...]
```
which would turn into:
```
[ None, 4, 3, None, None, None, None, ...]
[ None, None, 3, None, None, None, ...]
```

This requires https://github.com/stfc/PSyclone/pull/1368 to work right now.

The dependence analysis here is a prototype that will be used to build the `OMPTaskwaitTransformation` at a later stage. I am going to add comments to explain the process now too.