### PR TITLE
Update dl_timer location

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/stfc/dl_esm_inf.git
 [submodule "shared/dl_timer"]
 	path = shared/dl_timer
-	url = https://bitbucket.org/apeg/dl_timer
+	url = https://github.com/stfc/dl_timer.git
 [submodule "shared/FortCL"]
 	path = shared/FortCL
 	url = https://github.com/stfc/FortCL.git

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Various small benchmarks used to inform the development of the
 ## Obtaining the Code ##
 
 The benchmark codes contained in this project use the
-[dl_timer](https://bitbucket.org/apeg/dl_timer) library for execution
+[dl_timer](https://github.com/stfc/dl_timer) library for execution
 timing and the [dl_esm_inf](https://github.com/stfc/dl_esm_inf)
 infrastructure. Some implementation also have
 [PSyclone](https://github.com/stfc/PSyclone),


### PR DESCRIPTION
Should update the dl_timer submodules' location to the git repo.
@arporter @sergisiso Ready for a review assuming no failures.