### PR TITLE
Additions to scripts for ifx and gnu

### DIFF
--- a/compiler_setup/gnu.sh
+++ b/compiler_setup/gnu.sh
@@ -6,6 +6,9 @@ CXX=g++
 # Common optimization flags for CFLAGS and F90FLAGS
 OPTFLAGS=" -Ofast -mtune=native -finline-limit=50000 -fopt-info-all=gnu_opt_report.txt"
 
+# Vectorisation and extra math flags
+OPTFLAGS +="-ftree-vectorize -ffast-math"
+
 CFLAGS=$OPTFLAGS
 F90FLAGS="-Wall -Wsurprising -Wuninitialized"
 #F90FLAGS += -O0

--- a/compiler_setup/intel.sh
+++ b/compiler_setup/intel.sh
@@ -1,6 +1,6 @@
 # Build settings for the Intel compiler
-F90=ifort
-CC=icc
+F90=ifx
+CC=icx
 
 CFLAGS="-O3 -xHost -qopt-report"
 
@@ -19,24 +19,11 @@ F90FLAGS+=" -O3"
 #F90FLAGS+=" -axSSE4.2"
 #F90FLAGS+=" -xHost"
 
-# Profiling
-#F90FLAGS+=" -g -profile-loops=all"
-# -guide=4
-
-# Profile-guided optimisation
-#F90FLAGS+=" -prof-gen -prof-dir/tmp/profiled"
-#F90FLAGS+=" -prof-use -opt-report-phase=pgo"
-
-# Turn-off all compiler limits regarding in-lining of code
-F90FLAGS+=" -no-inline-min-size -no-inline-max-per-compile -no-inline-factor"
-#F90FLAGS+=" -fno-inline -fno-inline-functions -no-ipo"
-
 # For output of source-code-annotated assembler and reports
-#F90FLAGS+=" -S -fsource-asm -fverbose-asm"
-F90FLAGS+=" -qopt-report=5 -qopt-report-phase=loop,vec"
+F90FLAGS+=" -qopt-report=3 -qopt-report-phase=loop,vec"
 
 # Flags to switch-on OpenMP support in compiler
-OMPFLAGS="-qopenmp"
+OMPFLAGS="-fopenmp"
 
 LDFLAGS= 
 #LDFLAGS+= -fast


### PR DESCRIPTION
@arporter The changes here are for ifx, and additional flags I used for the AMD gnu runs.

I removed a bunch of flags from the intel file that are no longer available in ifx, and I couldn't see comparable flags.